### PR TITLE
rvd_front.pl - rel_dir deprecated

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
   VERSION   => '0.01',
   PREREQ_PM => {
-          'Mojolicious' => '6.15'
+          'Mojolicious' => '7.14'
      ,'DBIx::Connector' => 0
   ,'Authen::Passphrase' => 0
 	      ,'IPC::Run3'  => 0

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -1204,14 +1204,14 @@ sub init {
 
     if (exists $ENV{MORBO_VERBOSE}
         || (exists $ENV{MOJO_MODE} && $ENV{MOJO_MODE} =~ /devel/i )) {
-            return if -e $home->rel_dir("public");
+            return if -e $home->rel_file("public");
     }
     app->static->paths->[0] = ($CONFIG_FRONT->{dir}->{public}
-            or $home->rel_dir("public"));
+            or $home->rel_file("public"));
     app->renderer->paths->[0] =($CONFIG_FRONT->{dir}->{templates}
-            or $home->rel_dir("templates"));
+            or $home->rel_file("templates"));
     app->renderer->paths->[1] =($CONFIG_FRONT->{dir}->{custom}
-            or $home->rel_dir("templates"));
+            or $home->rel_file("templates"));
 
 }
 


### PR DESCRIPTION
Happy Hacktoberfest!

https://github.com/UPC/ravada/issues/229

`rel_dir` was deprecated in Mojolicious v7.14 and removed totally in 7.31.
Replaced `rel_dir` with `rel_file` in rvd_front.pl, bumped Mojolicious version in Makefile.PL
