### PR TITLE
[#390] Fix problems in Debian or Ubuntu 16.04 OS

### DIFF
--- a/etc/xml/dsl-i386.xml
+++ b/etc/xml/dsl-i386.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='i686' machine='pc-i440fx-trusty'>hvm</type>
+    <type arch='i686' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/jessie-amd64.xml
+++ b/etc/xml/jessie-amd64.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/jessie-i386.xml
+++ b/etc/xml/jessie-i386.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='i686' machine='pc-i440fx-trusty'>hvm</type>
+    <type arch='i686' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/trusty-amd64.xml
+++ b/etc/xml/trusty-amd64.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-trusty'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/trusty-i386.xml
+++ b/etc/xml/trusty-i386.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='i686' machine='pc-i440fx-trusty'>hvm</type>
+    <type arch='i686' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/win10.xml
+++ b/etc/xml/win10.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>4194304</currentMemory>
   <vcpu placement='static' current='2'>4</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/win7pro.xml
+++ b/etc/xml/win7pro.xml
@@ -12,7 +12,7 @@ or other application using the libvirt API.
   <currentMemory unit='KiB'>4194304</currentMemory>
   <vcpu placement='static'>2</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/win8.1.xml
+++ b/etc/xml/win8.1.xml
@@ -12,7 +12,7 @@ or other application using the libvirt API.
   <currentMemory unit='KiB'>4194304</currentMemory>
   <vcpu placement='static'>2</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/windows_10.xml
+++ b/etc/xml/windows_10.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-yakkety'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/windows_12.xml
+++ b/etc/xml/windows_12.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-yakkety'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/windows_7.xml
+++ b/etc/xml/windows_7.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-yakkety'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/windows_8.xml
+++ b/etc/xml/windows_8.xml
@@ -8,7 +8,7 @@
     <partition>/machine</partition>
   </resource>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-yakkety'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/windows_xp.xml
+++ b/etc/xml/windows_xp.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>524288</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-yakkety'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/xenial-i386.xml
+++ b/etc/xml/xenial-i386.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='i686' machine='pc-i440fx-trusty'>hvm</type>
+    <type arch='i686' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/xenial64-amd64.xml
+++ b/etc/xml/xenial64-amd64.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/yakkety64-amd64.xml
+++ b/etc/xml/yakkety64-amd64.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>

--- a/etc/xml/zesty-amd64.xml
+++ b/etc/xml/zesty-amd64.xml
@@ -5,7 +5,7 @@
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static'>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-xenial'>hvm</type>
+    <type arch='x86_64' machine='pc'>hvm</type>
   </os>
   <features>
     <acpi/>


### PR DESCRIPTION
If Ravada server has Debian or Ubuntu Xenial not supported machine type:
pc-i440fx-xenial or pc-i440fx-yakkety respectively

Fix with pc machine type is Standard PC (i440FX + PIIX, 1996) (alias of pc-i440fx-2.5) supported by both.

List machine supported in your server:
$qemu-system-x86_64 -machine help