### PR TITLE
UPDATE - English translation

### DIFF
--- a/lib/Ravada/I18N/en.po
+++ b/lib/Ravada/I18N/en.po
@@ -129,7 +129,7 @@ msgstr ""
 msgid "Password fields aren't equal"
 msgstr ""
 
-msgid "Some of the password's fields are empty"
+msgid "Some of the password fields are empty"
 msgstr ""
 
 msgid "Public"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Running"
 msgstr ""
 
-msgid "ShutDown"
+msgid "Shutdown"
 msgstr ""
 
 msgid "Screenshot"
@@ -268,7 +268,7 @@ msgid "e.g. VirtViewer v5.0-256, and USB drivers ("
 msgstr ""
 
 msgid ""
-"Be aware that in Windows, Spice redirection is not automatically. It's "
+"Be aware that in Windows, Spice redirection is not automatic. It's "
 "necessary to associate protocol with the app."
 msgstr ""
 
@@ -431,6 +431,6 @@ msgid "Create"
 msgstr ""
 
 msgid ""
-"can change the settings of any virtual machines "
+"can change the settings of all virtual machines "
 "cloned from one base owned by the user."
 msgstr ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed minor grammatical errors.
## Description
<!--- Describe your changes in detail -->
- `'s` is not required in sentence `Some of the password's fields are empty`.
- `Shutdown` is a single word.
- `automatically` needs to be followed by a verb. `automatic` is suitable here.
- either write `any virtual machine` or `all virtual machines`. `any virtual machines` is invalid.
## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/UPC/ravada/issues/411