### PR TITLE
[#512] use "view" instead of "start"

### DIFF
--- a/public/js/ravada.js
+++ b/public/js/ravada.js
@@ -281,12 +281,12 @@
     };
 
     function run_domain_ctrl($scope, $http, request ) {
-        $http.get('/auto_start').then(function(response) {
-            $scope.auto_start = response.auto_start;
+        $http.get('/auto_view').then(function(response) {
+            $scope.auto_view = response.auto_view;
         });
-        $scope.toggle_auto_start = function() {
-            $http.get('/auto_start/toggle').then(function(response) {
-                $scope.auto_start = response.auto_start;
+        $scope.toggle_auto_view = function() {
+            $http.get('/auto_view/toggle').then(function(response) {
+                $scope.auto_view = response.auto_view;
             });
         };
         $scope.copy_password= function() {

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -621,24 +621,24 @@ any '/settings' => sub {
     $c->render(template => 'main/settings');
 };
 
-any '/auto_start/(#value)/' => sub {
+any '/auto_view/(#value)/' => sub {
     my $c = shift;
     my $value = $c->stash('value');
     if ($value =~ /toggle/i) {
-        $value = $c->session('auto_start');
+        $value = $c->session('auto_view');
         if ($value) {
             $value = 0;
         } else {
             $value = 1;
         }
     }
-    $c->session('auto_start' => $value);
-    return $c->render(json => {auto_start => $c->session('auto_start') });
+    $c->session('auto_view' => $value);
+    return $c->render(json => {auto_view => $c->session('auto_view') });
 };
 
-get '/auto_start' => sub {
+get '/auto_view' => sub {
     my $c = shift;
-    return $c->render(json => {auto_start => $c->session('auto_start') });
+    return $c->render(json => {auto_view => $c->session('auto_view') });
 };
 
 ###################################################
@@ -1180,7 +1180,7 @@ sub show_link {
     _open_iptables($c,$domain)
         if !$req;
     my $uri_file = "/machine/display/".$domain->id;
-    $c->stash(url => $uri_file)  if $c->session('auto_start');
+    $c->stash(url => $uri_file)  if $c->session('auto_view') && ! $domain->spice_password;
     my ($display_ip, $display_port) = $uri =~ m{\w+://(\d+\.\d+\.\d+\.\d+):(\d+)};
     my $description = $domain->description;
     if (!$description && $domain->id_base) {

--- a/templates/main/run.html.ep
+++ b/templates/main/run.html.ep
@@ -42,16 +42,18 @@
                 <li><%=l 'Display IP:' %> <b><%= $display_ip %></b></li>
                 <li><%=l 'Display Port:' %> <b><%= $display_port %></b></li>
             </ul>
-            <label for="automatic"><input type="checkbox" ng-click="toggle_auto_start()"
-%           if ($c->session('auto_start')) {
+%           if (!$password) {
+            <label for="automatic"><input type="checkbox" ng-click="toggle_auto_view()"
+%           if ($c->session('auto_view')) {
                 checked
 %           }
-            > Start automatically next time</input>
+            > View automatically next time</input>
             <br/>
+%           }
             <a type="button" class="btn btn-success"
                     ng-click="copy_password()"
                     href="<%= $url_display_file %>">
-                <b><%=l 'start'%></b></a>
+                <b><%=l 'view'%></b></a>
 
         </div>
         <div class="panel-body">


### PR DESCRIPTION
It is misleading as the end user may think it can set
the machine to auto start. It is also enabled only for
password-less domains.
