### PR TITLE
[#536] Fix link

### DIFF
--- a/templates/main/list_bases2.html.ep
+++ b/templates/main/list_bases2.html.ep
@@ -43,7 +43,7 @@
             <div class="panel-heading">
 %           if ($user && $user->is_admin) {
                 <%=l 'There are no public bases available in this system.' %>
-                <a href="/admin/"><%=l 'Create one.' %></a>
+                <a href="/admin/machines"><%=l 'Create one.' %></a>
 %           } else {
                 <%=l 'There are no machines available in this system.' %>
 %           }


### PR DESCRIPTION
Fix "Create one" link to /admin/machines instead /admin

## Description
Link error when you don't have public bases in the message:
"There are no public bases available in this system. Create one."
"Create one" link to / admin and does not exist. I should link to / admin / machines
