### PR TITLE
start #797

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -79,8 +79,8 @@ our $DIR_SQL = "sql/mysql";
 $DIR_SQL = "/usr/share/doc/ravada/sql/mysql" if ! -e $DIR_SQL;
 
 # LONG commands take long
-our %HUGE_COMMAND = map { $_ => 1 } qw(download);
-our %LONG_COMMAND =  map { $_ => 1 } (qw(prepare_base remove_base screenshot shutdown force_shutdown ), keys %HUGE_COMMAND);
+our %HUGE_COMMAND = map { $_ => 1 } qw(download prepare_base remove_base);
+our %LONG_COMMAND =  map { $_ => 1 } (qw(screenshot shutdown force_shutdown ), keys %HUGE_COMMAND);
 
 our $USER_DAEMON;
 our $USER_DAEMON_NAME = 'daemon';

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -865,6 +865,7 @@ sub _enable_grants($self) {
         ,'manage_users'
         ,'remove',          'remove_all',   'remove_clone',     'remove_clone_all'
         ,'shutdown',        'shutdown_all',    'shutdown_clone'
+        ,'screenshot'
     );
 
     $sth = $CONNECTOR->dbh->prepare("SELECT id,name FROM grant_types");

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -801,6 +801,7 @@ sub _alias_grants($self) {
 
 sub _add_grants($self) {
     $self->_add_grant('shutdown', 1);
+    $self->_add_grant('screenshot', 1);
 }
 
 sub _add_grant($self, $grant, $allowed) {

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -368,6 +368,7 @@ sub can_list_own_machines {
         if $self->can_create_base()
             || $self->can_create_machine()
             || $self->can_remove_clone_all()
+            || $self->is_operator()
         ;
     return 0;
 }

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -585,7 +585,7 @@ sub can_do_domain($self, $grant, $domain) {
     my %valid_grant = map { $_ => 1 } qw(change_settings shutdown);
     confess "Invalid grant here '$grant'"   if !$valid_grant{$grant};
 
-    return 0 if !$self->can_do($grant);
+    return 0 if !$self->can_do($grant) && !$domain->id_base;
 
     return 1 if $self->can_do("${grant}_all");
     return 1 if $domain->id_owner == $self->id;
@@ -874,7 +874,7 @@ sub can_manage_machine($self, $domain) {
 
     return 1 if $self->can_remove && $domain->id_owner == $self->id;
 
-    if ( $self->can_remove_clones && $domain->id_base ) {
+    if ( ($self->can_remove_clones || $self->can_change_settings_clones) && $domain->id_base ) {
         my $base = Ravada::Front::Domain->open($domain->id_base);
         return 1 if $base->id_owner == $self->id;
     }

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -863,6 +863,8 @@ sub can_manage_machine($self, $domain) {
 
     return 1 if $self->can_change_settings($domain);
 
+    return 1 if $self->can_remove_all;
+
     return 1 if $self->can_remove_clone_all
         && $domain->id_base;
 

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -797,7 +797,7 @@ Returns a list of all the available permissions
 =cut
 
 sub list_all_permissions($self) {
-    return if !$self->is_admin;
+    return if !$self->is_admin && !$self->can_grant();
     $self->_load_grants();
 
     my $sth = $$CON->dbh->prepare(

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -406,7 +406,9 @@ sub can_list_machines {
     return 1 if $self->is_admin()
             || $self->can_remove_all || $self->can_remove_clone_all
             || $self->can_shutdown_all
-            || $self->can_change_settings_all();
+            || $self->can_change_settings_all()
+            || $self->can_change_settings_clones()
+            || $self->can_clone_all();
     return 0;
 }
 
@@ -867,6 +869,8 @@ sub can_manage_machine($self, $domain) {
 
     return 1 if $self->can_remove_clone_all
         && $domain->id_base;
+    
+    return 1 if $self->can_clone_all;
 
     if ( $self->can_remove_clones && $domain->id_base ) {
         my $base = Ravada::Front::Domain->open($domain->id_base);

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -872,6 +872,8 @@ sub can_manage_machine($self, $domain) {
     
     return 1 if $self->can_clone_all;
 
+    return 1 if $self->can_remove && $domain->id_owner == $self->id;
+
     if ( $self->can_remove_clones && $domain->id_base ) {
         my $base = Ravada::Front::Domain->open($domain->id_base);
         return 1 if $base->id_owner == $self->id;
@@ -897,7 +899,7 @@ sub can_remove_clones($self, $id_domain=undef) {
 
 sub can_remove_machine($self, $domain) {
     return 1 if $self->can_remove_all();
-    return 0 if !$self->can_remove();
+    #return 0 if !$self->can_remove();
 
     $domain = Ravada::Front::Domain->open($domain)   if !ref $domain;
 

--- a/lib/Ravada/Auth/SQL.pm
+++ b/lib/Ravada/Auth/SQL.pm
@@ -847,6 +847,15 @@ sub can_change_settings($self, $id_domain=undef) {
 
 =cut
 
+=head2 can_manage_machine
+
+The user can change settings, remove or change other things yet to be defined.
+Some changes require special permissions granted.
+
+Unlinke change_settings that any user is granted to his own machines by default.
+
+=cut
+
 sub can_manage_machine($self, $domain) {
     return 1 if $self->is_admin;
 

--- a/lib/Ravada/Domain.pm
+++ b/lib/Ravada/Domain.pm
@@ -550,8 +550,17 @@ sub _data($self, $field, $value=undef, $table='domains') {
     }
     return $self->{$data}->{$field} if exists $self->{$data}->{$field};
 
-    my @field_select = ( name => $self->name );
-    @field_select = ( id_domain => $self->id )         if $table ne 'domains';
+    my @field_select;
+    if ($table eq 'domains' ) {
+        if (exists $self->{_data}->{id} ) {
+            @field_select = ( id => $self->{_data}->{id});
+        } else {
+            confess "ERROR: Unknown domain" if ref($self) =~ /^Ravada::Front::Domain/;
+            @field_select = ( name => $self->name );
+        }
+    } else {
+        @field_select = ( id_domain => $self->id );
+    }
     $self->{$data} = $self->_select_domain_db( _table => $table, @field_select );
 
     confess "No DB info for domain @field_select in $table ".$self->name 

--- a/lib/Ravada/Domain.pm
+++ b/lib/Ravada/Domain.pm
@@ -1379,6 +1379,7 @@ sub _post_shutdown {
     $self->_remove_iptables(%arg);
     $self->_data(status => 'shutdown')
         if $self->is_known && !$self->is_volatile && !$self->is_active;
+
     if ($self->is_known && $self->id_base) {
         for ( 1 ..  5 ) {
             last if !$self->is_active;
@@ -1404,6 +1405,7 @@ sub _post_shutdown {
 }
 
 sub _around_is_active($orig, $self) {
+    return 0 if $self->is_removed;
     my $is_active = $self->$orig();
     return $is_active if $self->readonly
         || !$self->is_known

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -136,6 +136,7 @@ sub list_machines_user {
 
     my @list;
     while ( $sth->fetch ) {
+        next if !$is_public && !$user->is_admin;
         my $is_active = 0;
         my $clone = $self->search_clone(
             id_owner =>$user->id

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -194,7 +194,7 @@ sub list_machines($self, $user) {
 
     }
     push @list,(@{$self->list_clones()}) if $user->can_list_clones;
-    if ($user->can_create_base) {
+    if ($user->can_create_base || $user->can_create_machine) {
         my $machines = $self->list_domains(id_owner => $user->id);
         for my $clone (@$machines) {
             next if !$clone->{id_base};

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -194,7 +194,7 @@ sub list_machines($self, $user) {
 
     }
     push @list,(@{$self->list_clones()}) if $user->can_list_clones;
-    if ($user->can_create_base || $user->can_create_machine) {
+    if ($user->can_create_base || $user->can_create_machine || $user->is_operator) {
         my $machines = $self->list_domains(id_owner => $user->id);
         for my $clone (@$machines) {
             next if !$clone->{id_base};

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -185,14 +185,22 @@ sub list_machines($self, $user) {
         }
         push @list,(@$machines);
     }
-    if ($user->can_remove_clone_all()) {
+
+=pod
+
+if ($user->can_remove_clone_all()) {
         my $machines = $self->list_bases( );
         for my $base (@$machines) {
-            push @$machines,@{$self->list_domains( id_base => $base->{id} )};
+            my $clones = $self->list_domains( id_base => $base->{id} );
+            next if !scalar @$clones;
+            push @list, ($base);
+            push @list, @{$clones};
         }
-        push @list,(@$machines);
 
     }
+
+=cut
+
     push @list,(@{$self->list_clones()}) if $user->can_list_clones;
     if ($user->can_create_base || $user->can_create_machine || $user->is_operator) {
         my $machines = $self->list_domains(id_owner => $user->id);

--- a/lib/Ravada/Front/Domain.pm
+++ b/lib/Ravada/Front/Domain.pm
@@ -82,7 +82,7 @@ sub is_paused($self) {
     return 0;
 }
 
-sub is_removed          { confess "TODO" }
+sub is_removed          { return 0 }
 sub list_volumes        { confess "TODO" }
 
 sub name($self) {

--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -1519,7 +1519,6 @@ sub _xml_add_usb_xhci {
     $address->setAttribute(bus => '0x00');
     $address->setAttribute(slot => '0x07');
     $address->setAttribute(function => '0x0');
-    
 }
 
 sub _xml_add_usb_ehci1 {

--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -608,7 +608,7 @@ sub _domain_create_from_iso {
     my $device_cdrom;
 
     confess "Template ".$iso->{name}." has no URL, iso_file argument required."
-        if !$iso->{url} && !$args{iso_file} && !$iso->{device};
+        if !$iso->{url} && !$iso_file && !$iso->{device};
 
     if ($iso_file) {
         if ( $iso_file ne "<NONE>") {

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -51,3 +51,7 @@
     background: #4CAF50; /* Green background */
     cursor: pointer; /* Cursor on hover */
 }
+
+.disabled {
+    color: darkgray;
+    cursor: not-allowed;

--- a/public/js/ravada.js
+++ b/public/js/ravada.js
@@ -316,6 +316,7 @@
                     }
                     if ($scope.domain.is_active) {
                         seconds = 5000;
+                        $scope.redirect();
                     }
                     $timeout(function() {
                         $scope.get_domain_info();
@@ -325,7 +326,6 @@
 
         };
         $scope.wait_request = function() {
-            console.log("id_request: "+$scope.id_request);
             $scope.dots += '.';
             if ($scope.id_request) {
                 $http.get('/request/'+$scope.id_request+'.json').then(function(response) {
@@ -360,8 +360,17 @@
 
             }
         };
+        $scope.redirect = function() {
+            if (!$scope.redirect_done) {
+                $timeout(function() {
+                    window.location.href="/logout";
+                }, 60000);
+                $scope.redirect_done = true;
+            }
+        }
 
         $scope.dots = '...';
+        $scope.redirect_done = false;
         $scope.wait_request();
         $scope.view_clicked=false;
     };

--- a/public/js/ravada.js
+++ b/public/js/ravada.js
@@ -94,7 +94,7 @@
                 $http.get(toGet);
             };
             $scope.action = function(machineId, action) {
-                $scope.refresh = true;
+                $scope.refresh = 2;
                 if ( action == 'restore' ) {
                     $scope.host_restore = machineId;
                     $scope.host_shutdown = 0;
@@ -109,14 +109,16 @@
             };
 
             $scope.list_machines_user = function() {
-                var seconds = 5000;
-                if ($scope.refresh) {
+                var seconds = 1000;
+                if ($scope.refresh <= 0) {
                     $http.get('/list_machines_user.json').then(function(response) {
                         $scope.machines = response.data;
+                    }, function error(response) {
+                        console.log(response.status);
                     });
+                    $scope.refresh = 5;
                 } else {
-                    seconds = 60000;
-                    $scope.refresh = true;
+                    $scope.refresh--;
                 }
                 $timeout(function() {
                         $scope.list_machines_user();
@@ -141,7 +143,7 @@
             };
             $scope.startIntro = startIntro;
             $scope.host_action = 0;
-            $scope.refresh = true;
+            $scope.refresh = 0;
             $scope.list_machines_user();
         };
 

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -1322,7 +1322,10 @@ sub settings_machine {
     my $c = shift;
     my ($domain) = _search_requested_machine($c);
     return access_denied($c)    if !$domain;
-  	return access_denied($c)    if !($USER->can_manage_machine($domain->id) || $USER->is_admin);
+  	return access_denied($c)    if !($USER->can_manage_machine($domain->id)
+                                    || $USER->can_change_settings($domain->id)
+                                    || $USER->is_admin
+    );
 
     $c->stash(domain => $domain);
     $c->stash(USER => $USER);

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -525,7 +525,7 @@ any '/users/register' => sub {
 
 any '/admin/user/(:id).(:type)' => sub {
     my $c = shift;
-    return access_denied($c) if !$USER->can_manage_users();
+    return access_denied($c) if !$USER->can_manage_users() && !$USER->can_grant();
 
     my $user = Ravada::Auth::SQL->search_by_id($c->stash('id'));
 

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -998,6 +998,7 @@ sub admin {
     push @{$c->stash->{js}}, '/js/admin.js';
 
     if ($page eq 'users') {
+        return access_denied($c)    if !$USER->is_admin && !$USER->can_manage_users && !$USER->can_grant;
         $c->stash(list_users => []);
         $c->stash(name => $c->param('name' or ''));
         if ( $c->param('name') ) {

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -989,7 +989,7 @@ sub admin {
     }
     if ($page eq 'machines') {
         $c->stash(hide_clones => 0 );
-        my $list_domains = $RAVADA->list_domains();
+        my $list_domains = $RAVADA->list_machines($USER);
 
         $c->stash(hide_clones => 1 )
             if defined $CONFIG_FRONT->{admin}->{hide_clones}

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -1325,6 +1325,9 @@ sub settings_machine {
   	return access_denied($c)    if !($USER->can_manage_machine($domain->id)
                                     || $USER->can_change_settings($domain->id)
                                     || $USER->is_admin
+                                    || $USER->can_remove_clone_all()
+                                    || $USER->can_remove_clone()
+                                    || $USER->can_clone_all()
     );
 
     $c->stash(domain => $domain);

--- a/t/front/20_create_domain.t
+++ b/t/front/20_create_domain.t
@@ -78,6 +78,23 @@ sub test_list_bases {
     ok(scalar @$bases == $expected,"Expecting '$expected' bases, got ".scalar @$bases);
 }
 
+sub test_domain_name {
+    my $vm_name = shift;
+
+    my $domain = create_domain($vm_name);
+    my $sth = $test->connector->dbh->prepare("DELETE FROM domains WHERE id=?");
+    $sth->execute($domain->id);
+
+    my $id = $domain->id;
+
+    $domain = Ravada::Front::Domain->open($id);
+    eval {
+        $domain->name();
+    };
+    like($@,qr'Unknown domain');
+
+}
+
 ####################################################################
 #
 
@@ -156,6 +173,7 @@ for my $vm_name ('Void','KVM','LXC') {
 
 
     test_remove_domain($name);
+    test_domain_name($vm_name);
 }
 }
 

--- a/t/front/40_list_domains.t
+++ b/t/front/40_list_domains.t
@@ -79,6 +79,28 @@ sub test_list_domains {
     is($list_domains->[0]->{is_active}, 1);
 }
 
+sub test_list_bases {
+    my $vm_name = shift;
+
+    my $vm = rvd_back->search_vm($vm_name);
+
+    my $user2 = create_user('malcolm.reynolds','serenity');
+
+    my $base = create_domain($vm_name);
+    my $list = rvd_front->list_machines_user($user2);
+    is(scalar @$list, 0);
+
+    $base->prepare_base(user_admin);
+
+    $list = rvd_front->list_machines_user($user2);
+    is(scalar @$list, 0);
+
+    $list = rvd_front->list_machines_user(user_admin);
+    is(scalar @$list, 1);
+
+    $base->remove(user_admin);
+    $user2->remove();
+}
 #########################################################
 
 remove_old_domains();
@@ -112,6 +134,8 @@ for my $vm_name (reverse sort @VMS) {
 
         my $domain = test_create_domain($vm_name);
         test_list_domains($vm_name, $domain);
+
+        test_list_bases($vm_name);
         $domain->remove($USER);
 
     }

--- a/t/user/20_grants.t
+++ b/t/user/20_grants.t
@@ -370,6 +370,16 @@ sub test_remove_clone_all {
 
     $clone_name = new_domain_name();
     $clone = $domain->clone(user => $usera, name => $clone_name);
+
+    my $other_domain = create_domain($vm_name);
+    ok($other_domain);
+
+    is($user->is_admin, 0);
+    is($user->can_list_machines, 1);
+    my $list = rvd_front->list_machines($user);
+    is(scalar@$list,4);
+    ok( grep { $_->{name} eq $other_domain->name } @$list);
+
     $usera->revoke($user,'remove_clone_all');
 
     eval { $clone->remove($user); };

--- a/t/user/20_grants.t
+++ b/t/user/20_grants.t
@@ -505,6 +505,7 @@ sub test_create_domain {
             ,name => $domain_name
    );
 
+
     my $domain;
     eval { $domain = $vm->create_domain(%create_args)};
     like($@,qr'not allowed'i);
@@ -535,6 +536,9 @@ sub test_create_domain {
     ok($domain3);
 
     is($user->can_change_settings($domain3),1);
+
+    my $list_machines = rvd_front->list_machines($user);
+    is (scalar @$list_machines, 1 );
 
     eval { $domain3->remove($usera)  if $domain3 };
     is($@,'');

--- a/t/user/20_grants.t
+++ b/t/user/20_grants.t
@@ -448,9 +448,17 @@ sub test_frontend {
     is($user->can_list_machines, 0);
     is($user->can_list_own_machines, 1);
 
-    my $list_machines = rvd_front->list_domains( id_owner => $user->id );
-    is (scalar @$list_machines, 1 );
-    ok($list_machines->[0]->{name} eq $clone->name);
+    my $list_domains = rvd_front->list_domains( id_owner => $user->id );
+    is (scalar @$list_domains, 1 );
+    ok($list_domains->[0]->{name} eq $clone->name);
+
+    my $list_machines = rvd_front->list_machines( $user );
+    is (scalar @$list_machines, 2 );
+    if (defined $list_machines->[1]) {
+        ok($list_machines->[1]->{name} eq $clone->name);
+        is($list_machines->[1]->{can_manage}, 1);
+        is($list_machines->[0]->{can_manage}, 0);
+    }
 
     $usera->revoke($user, 'create_base');
     is($user->can_list_machines, 0);
@@ -526,6 +534,7 @@ sub test_create_domain {
     my $domain3 = $vm->search_domain($domain_name);
     ok($domain3);
 
+    is($user->can_change_settings($domain3),1);
 
     eval { $domain3->remove($usera)  if $domain3 };
     is($@,'');

--- a/t/user/30_grant_remove.t
+++ b/t/user/30_grant_remove.t
@@ -183,6 +183,7 @@ sub test_list_clones_from_own_base {
 
     user_admin->grant($user,'create_machine');
     my $base = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
 
     $base->prepare_base( user_admin );
     $base->is_public(1);
@@ -215,6 +216,7 @@ sub test_list_clones_from_own_base_2 {
 
     user_admin->grant($user,'create_machine');
     my $base = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
 
     $base->prepare_base( user_admin );
     $base->is_public(1);
@@ -245,7 +247,9 @@ sub test_list_clones_from_own_base_2 {
     #####################################################################3
     #
     # another base
+    user_admin->grant($user,'create_machine');
     my $base2 = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
     $base2->prepare_base(user_admin);
     $base2->is_public(1);
 

--- a/t/user/30_grant_remove.t
+++ b/t/user/30_grant_remove.t
@@ -169,6 +169,8 @@ sub test_list_all{
     user_admin->grant($user, 'remove_all');
     is($user->can_list_machines, 1);
 
+    is($user->can_manage_machine($base),1);
+
     $list = rvd_front->list_machines($user);
     is(scalar @$list , 2);
 

--- a/t/user/30_grant_remove.t
+++ b/t/user/30_grant_remove.t
@@ -256,10 +256,10 @@ sub test_list_clones_from_own_base_2 {
     $list = rvd_front->list_machines($user);
     is(scalar @$list , 5) and do {
         is($list->[0]->{name}, $base->name);
-        is($list->[1]->{name}, $base2->name);
-        is($list->[2]->{name}, $clone->name, Dumper($list->[2]));
-        is($list->[3]->{name}, $clone2->name, Dumper($list->[3]));
-        is($list->[4]->{name}, $clone3->name, Dumper($list->[4]));
+        is($list->[1]->{name}, $clone->name);
+        is($list->[2]->{name}, $clone2->name);
+        is($list->[3]->{name}, $base2->name);
+        is($list->[4]->{name}, $clone3->name);
     };
 
     for my $m (@$list) {

--- a/t/user/40_grant_shutdown.t
+++ b/t/user/40_grant_shutdown.t
@@ -271,10 +271,10 @@ sub test_list_clones_from_own_base_2 {
     $list = rvd_front->list_machines($user);
     is(scalar @$list , 5) and do {
         is($list->[0]->{name}, $base->name);
-        is($list->[1]->{name}, $base2->name);
-        is($list->[2]->{name}, $clone->name, Dumper($list->[2]));
-        is($list->[3]->{name}, $clone2->name, Dumper($list->[3]));
-        is($list->[4]->{name}, $clone3->name, Dumper($list->[4]));
+        is($list->[1]->{name}, $clone->name);
+        is($list->[2]->{name}, $clone2->name);
+        is($list->[3]->{name}, $base2->name);
+        is($list->[4]->{name}, $clone3->name);
     };
 
     for my $m (@$list) {

--- a/t/user/40_grant_shutdown.t
+++ b/t/user/40_grant_shutdown.t
@@ -194,6 +194,7 @@ sub test_list_clones_from_own_base {
 
     user_admin->grant($user,'create_machine');
     my $base = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
 
     $base->prepare_base( user_admin );
     $base->is_public(1);
@@ -228,6 +229,7 @@ sub test_list_clones_from_own_base_2 {
 
     user_admin->grant($user,'create_machine');
     my $base = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
 
     $base->prepare_base( user_admin );
     $base->is_public(1);
@@ -260,7 +262,9 @@ sub test_list_clones_from_own_base_2 {
     #####################################################################3
     #
     # another base
+    user_admin->grant($user,'create_machine');
     my $base2 = create_domain($vm->type, $user);
+    user_admin->revoke($user,'create_machine');
     $base2->prepare_base(user_admin);
     $base2->is_public(1);
 

--- a/templates/bootstrap/navigation.html.ep
+++ b/templates/bootstrap/navigation.html.ep
@@ -25,7 +25,7 @@ navbar-inverse navbar-fixed-top" role="navigation">
                     <li><a href="/admin/machines">
                       <i class="fa fa-desktop" aria-hidden="true"></i>&nbsp<%=l 'machines' %></a>
                     </li>
-%                   if ($_user->is_admin) {
+%                   if ($_user->is_admin || $_user->can_grant) {
                         <li><a href="/admin/users">
                         <i class="fa fa-user" aria-hidden="true"></i>&nbsp<%=l 'users' %></a>
                         </li>

--- a/templates/bootstrap/navigation.html.ep
+++ b/templates/bootstrap/navigation.html.ep
@@ -25,7 +25,7 @@ navbar-inverse navbar-fixed-top" role="navigation">
                     <li><a href="/admin/machines">
                       <i class="fa fa-desktop" aria-hidden="true"></i>&nbsp<%=l 'machines' %></a>
                     </li>
-%                   if ($_user->is_admin || $_user->can_grant) {
+%                   if ($_user->is_admin || $_user->can_grant || $_user->can_manage_users) {
                         <li><a href="/admin/users">
                         <i class="fa fa-user" aria-hidden="true"></i>&nbsp<%=l 'users' %></a>
                         </li>

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -158,9 +158,9 @@
             <tbody>
                 <tr ng-repeat-start="machine in list_machines | orderBy : orderParam">
                     <td class="lgMachName">
-                        <a align="right" href="/machine/settings/{{machine.id}}.html"
-                                         ng-class="{disabled: !machine.can_change_settings}"
-                        title ="<%=l 'Machine settings' %>"><b
+                        <a align="right" href="/machine/manage/{{machine.id}}.html"
+                                         ng-class="{disabled: !machine.can_manage}"
+                        title ="<%=l 'Manage machine' %>"><b
                         ng-cloak>{{machine.name}}</b></a>
                     </td>
                     <td class="lgMachToggle">
@@ -276,9 +276,9 @@
                       <td class="lgMachName">
                           &nbsp;<i title="[cloned]" class="fa fa-fw fa-long-arrow-right"
                               style="color:white"></i>
-                          <a align="right" href="/machine/settings/{{child.id}}.html"
-                                         ng-class="{disabled: !child.can_change_settings}"
-                          title ="Machine settings"><i
+                          <a align="right" href="/machine/manage/{{child.id}}.html"
+                                         ng-class="{disabled: !child.can_manage}"
+                          title ="Manage machine"><i
                              ng-cloak>&nbsp;{{child.name}}</i></a>
                           <span style="color:gray">[ Cloned ]</span>
                       </td>

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -159,6 +159,7 @@
                 <tr ng-repeat-start="machine in list_machines | orderBy : orderParam">
                     <td class="lgMachName">
                         <a align="right" href="/machine/settings/{{machine.id}}.html"
+                                         ng-class="{disabled: !machine.can_change_settings}"
                         title ="<%=l 'Machine settings' %>"><b
                         ng-cloak>{{machine.name}}</b></a>
                     </td>
@@ -276,6 +277,7 @@
                           &nbsp;<i title="[cloned]" class="fa fa-fw fa-long-arrow-right"
                               style="color:white"></i>
                           <a align="right" href="/machine/settings/{{child.id}}.html"
+                                         ng-class="{disabled: !child.can_change_settings}"
                           title ="Machine settings"><i
                              ng-cloak>&nbsp;{{child.name}}</i></a>
                           <span style="color:gray">[ Cloned ]</span>

--- a/templates/main/list_bases_ng.html.ep
+++ b/templates/main/list_bases_ng.html.ep
@@ -24,7 +24,7 @@
                     <i ng-show="!machine.is_public">(<%=l 'not public' %>)</i>
                 </h3>
                 <a ng-show="machine.screenshot" href="/machine/clone/{{machine.id}}.html"><img
-                    src="{{machine.screenshot}}" class="img-thumbnail" width="260"
+                    ng-src="{{machine.screenshot}}" class="img-thumbnail" width="260"
                     alt="{{machine.description}}"></a>
                 <a ng-show="!machine.screenshot" href="/machine/clone/{{machine.id}}.html"><img
                     src="/img/default_screenshot.png" class="screenshot-default img-thumbnail"

--- a/templates/main/list_bases_ng.html.ep
+++ b/templates/main/list_bases_ng.html.ep
@@ -36,22 +36,22 @@
                    href="/machine/clone/{{machine.id}}.html"><strong><i class="fa fa-play" aria-hidden="true"></i>&nbsp;<%=l 'Start' %></strong></a>
                 <a type="button" class="btn btn-danger"
                     ng-show="machine.id_clone && !machine.is_active"
-                    ng-click="host_restore=machine.id_clone"
+                    ng-click="host_restore=machine.id_clone; $parent.refresh=20"
                     ><strong><i class="fas fa-redo" aria-hidden="true"></i>&nbsp;<%=l 'Restore' %></strong></a>
                     <div ng-show="machine.id_clone && host_restore == machine.id_clone">
                         <b><%=l 'Restore' %></b> <%=l 'will remove all the contents of the machine' %>
                         <i><b>{{machine.name_clone}}</b></i>.
                         <%=l 'Are you sure?' %><br/>
                         <a type="button" class="btn btn-danger"
-                            ng-click="host_restore=0"
+                            ng-click="host_restore=0; host_action=0"
                         ><%=l 'No' %></a>
                         <a type="button" class="btn btn-warning"
-                            ng-click="restore(machine.id_clone)"
+                            ng-click="restore(machine.id_clone);host_restore=0;host_action=0"
                             ><%=l 'Yes' %></a>
                     </div>
                  <a ng-show="machine.is_active && host_action != machine.id"
                         class="btn btn-default"
-                        ng-click="host_action=machine.id;$parent.refresh=false"
+                        ng-click="host_action=machine.id;$parent.refresh=20"
                         type="button"><%=l 'action'%></a>
                     <span
                             ng-show="host_action == machine.id && !host_restore"

--- a/templates/main/list_bases_ng.html.ep
+++ b/templates/main/list_bases_ng.html.ep
@@ -76,7 +76,7 @@
                     </span>
 %			        if ($user->can_change_settings || $user->can_change_settings_all){
                         <a ng-show="host_action != machine.id && host_restore != machine.id_clone"
-                            align="right" href="/machine/settings/{{machine.id_clone}}.html"><i class="fa fa-fw fa-cog" title="<%=l 'Settings' %>"></a></i>
+                            align="right" href="/machine/manage/{{machine.id_clone}}.html"><i class="fa fa-fw fa-cog" title="<%=l 'Settings' %>"></a></i>
 %                   }
 
             </div>

--- a/templates/main/list_bases_ng.html.ep
+++ b/templates/main/list_bases_ng.html.ep
@@ -76,7 +76,7 @@
                     </span>
 %			        if ($user->can_change_settings || $user->can_change_settings_all){
                         <a ng-show="host_action != machine.id && host_restore != machine.id_clone"
-                            align="right" href="/machine/settings/{{machine.id}}.html"><i class="fa fa-fw fa-cog" title="<%=l 'Settings' %>"></a></i>
+                            align="right" href="/machine/settings/{{machine.id_clone}}.html"><i class="fa fa-fw fa-cog" title="<%=l 'Settings' %>"></a></i>
 %                   }
 
             </div>

--- a/templates/main/settings_machine_tabs_head.html.ep
+++ b/templates/main/settings_machine_tabs_head.html.ep
@@ -17,7 +17,7 @@
 %   if ($domain->drivers && $USER->can_change_settings($domain->id)) {
         <li class="nav"><a href="#graphics" data-toggle="tab"><%=l 'Graphics' %></a></li>
 %   }
-%   if ($USER->is_admin){
+%   if ($USER->is_admin || $USER->can_clone_all ){
         <li class="nav"><a href="#copy" data-toggle="tab"><%=l 'Copy' %></a></li>
 %   }
 %   if ( $USER->can_remove_machine($domain->id)) {


### PR DESCRIPTION
New Start screens more responsible for end user.
 - Machine listing in main screen is dynamic without need to reload
 - It shows informative messages about waiting for new machine to start
 - Shows errors if request fails

Backend improvements:
 - Allow start machines even if prepare and remove base are running in background