### PR TITLE
fix(frontend):broken badge

### DIFF
--- a/templates/bootstrap/footer.html.ep
+++ b/templates/bootstrap/footer.html.ep
@@ -7,6 +7,7 @@
 %if ($version =~ /(alpha|beta)/) {
           <a href="https://github.com/UPC/ravada/releases"><%= $version %></a>
 % } else {
+% $version =~ s/-/--/g;
           <a href="https://github.com/UPC/ravada/releases"><img src="https://img.shields.io/badge/version-<%= $version %>-brightgreen.svg"></a>
 % }
           <a href="https://github.com/UPC/ravada/blob/master/LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg"></a>


### PR DESCRIPTION
If version content a dash, for example: 0.3.0-rc2
Issue [#908]