### PR TITLE
fix: Buttons disabled on machines permit action

### DIFF
--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -237,33 +237,33 @@
                     </td>
                     <td class="lgMachToggle">
                       <div ng-hide="{{machine.is_locked||machine.is_base}}">
-                        <a type="button" class="btn btn-success btn-sm"
+                        <button type="button" class="btn btn-success btn-sm"
                          ng-click="action('machine','start',machine.id)"
                          ng-disabled="machine.is_active"
                          ng-show="machine.can_start"
                          title="<%=l 'Start' %>">
                          <i class="fa fa-play"></i>
-                        </a>
-                        <a type="button" class="btn btn-warning btn-sm"
+                        </button>
+                        <button type="button" class="btn btn-warning btn-sm"
                          ng-click="action('machine','hibernate',machine.id)"
                          ng-disabled="!machine.is_active"
                          ng-show="machine.can_hibernate"
                          title="<%=l 'Hibernate' %>">
                           <i class="fa fa-pause"></i>
-                       </a>
-                        <a type="button" class="btn btn-danger btn-sm"
+                       </button>
+                        <button type="button" class="btn btn-danger btn-sm"
                          ng-click="action('machine','shutdown',machine.id)"
                          ng-disabled="!machine.is_active"
                          ng-show="machine.can_shutdown"
                          title="<%=l 'ShutDown' %>">
                           <i class="fa fa-power-off"></i>
-                       </a>
-                        <a type="button" class="btn btn-primary btn-sm"
+                       </button>
+                        <button type="button" class="btn btn-primary btn-sm"
                          ng-show="machine.can_view"
                          ng-href="/machine/view/{{machine.id}}.html"
                          title="<%=l 'View' %>">
                           <i class="fa fa-desktop"></i>
-                        </a>
+                        </button>
                       </div>
                       <div ng-show="{{machine.is_locked}}" ng-cloak>Machine locked by <a href="/request/{{machine.is_locked}}.html"><%=l 'process' %></a></div>
                       <div ng-show="{{machine.is_base}} && !{{machine.is_locked}}"

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -258,12 +258,12 @@
                          title="<%=l 'ShutDown' %>">
                           <i class="fa fa-power-off"></i>
                        </button>
-                        <button type="button" class="btn btn-primary btn-sm"
+                        <a type="button" class="btn btn-primary btn-sm"
                          ng-show="machine.can_view"
                          ng-href="/machine/view/{{machine.id}}.html"
                          title="<%=l 'View' %>">
                           <i class="fa fa-desktop"></i>
-                        </button>
+                        </a>
                       </div>
                       <div ng-show="{{machine.is_locked}}" ng-cloak>Machine locked by <a href="/request/{{machine.is_locked}}.html"><%=l 'process' %></a></div>
                       <div ng-show="{{machine.is_base}} && !{{machine.is_locked}}"
@@ -359,27 +359,27 @@
                       <td class="lgMachToggle">
 
                         <div ng-hide="{{child.is_locked}}">
-                          <a type="button" class="btn btn-success btn-sm"
+                          <button type="button" class="btn btn-success btn-sm"
                            ng-click="action('machine','start',child.id)"
                            ng-disabled="child.is_active"
                            ng-show="child.can_start"
                            title="<%=l 'Start' %>">
                             <i class="fa fa-play"></i>
-                          </a>
-                          <a type="button" class="btn btn-warning btn-sm"
+                          </button>
+                          <button type="button" class="btn btn-warning btn-sm"
                             ng-click="action('machine','hibernate',child.id)"
                             ng-disabled="!child.is_active"
                            ng-show="child.can_hibernate"
                             title="<%=l 'Hibernate' %>">
                             <i class="fa fa-pause"></i>
-                          </a>
-                          <a type="button" class="btn btn-danger btn-sm"
+                          </button>
+                          <button type="button" class="btn btn-danger btn-sm"
                            ng-click="action('machine','shutdown',child.id)"
                            ng-disabled="!child.is_active"
                            ng-show="child.can_shutdown"
                            title="<%=l 'ShutDown' %>">
                             <i class="fa fa-power-off"></i>
-                         </a>
+                         </button>
                           <a type="button" class="btn btn-primary btn-sm"
                            ng-href="/machine/view/{{child.id}}.html"
                            ng-show="child.can_view"


### PR DESCRIPTION
change buttons from type anchor to type button for to do directive ng-disabled correctly

fixes #914

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
