### PR TITLE
Feature/918 pxe

### DIFF
--- a/etc/xml/empty-amd64.xml
+++ b/etc/xml/empty-amd64.xml
@@ -1,0 +1,76 @@
+<domain type='kvm'>
+  <name>empty-x64</name>
+  <uuid>1805fb4f-ca45-a946-efbf-94124e760484</uuid>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc'>hvm</type>
+    <boot dev='network'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>/usr/bin/kvm-spice</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/empty-x64.img'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:a7:49:36'/>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target port='0'/>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+      <image compression='auto_glz'/>
+      <jpeg compression='auto'/>
+      <zlib compression='auto'/>
+      <playback compression='on'/>
+      <streaming mode='filter'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/etc/xml/empty-i386.xml
+++ b/etc/xml/empty-i386.xml
@@ -1,0 +1,107 @@
+<domain type='kvm' id='26'>
+  <name>test-net-boot</name>
+  <uuid>1805fb4f-ca45-aaaa-bbbb-94124e739131</uuid>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='i686' machine='pc'>hvm</type>
+    <boot dev='network'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>/usr/bin/kvm-spice</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/empty-i386.img'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </disk>
+    <controller type='pci' index='0' model='pci-root'>
+      <alias name='pci.0'/>
+    </controller>
+    <controller type='ide' index='0'>
+      <alias name='ide'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='nec-xhci'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:a7:49:34'/>
+      <source network='default' bridge='virbr0'/>
+      <target dev='vnet0'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <source path='/dev/pts/2'/>
+      <target port='0'/>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/2'>
+      <source path='/dev/pts/2'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <input type='mouse' bus='ps2'>
+      <alias name='input0'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+      <listen type='address' address='127.0.0.1'/>
+      <image compression='auto_glz'/>
+      <jpeg compression='auto'/>
+      <zlib compression='auto'/>
+      <playback compression='on'/>
+      <streaming mode='filter'/>
+    </graphics>
+    <sound model='ich6'>
+      <alias name='sound0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir0'/>
+      <address type='usb' bus='0' port='1'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir1'/>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <alias name='redir2'/>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>
+

--- a/etc/xml/empty-i386.xml
+++ b/etc/xml/empty-i386.xml
@@ -1,5 +1,5 @@
 <domain type='kvm' id='26'>
-  <name>test-net-boot</name>
+  <name>empty-i386</name>
   <uuid>1805fb4f-ca45-aaaa-bbbb-94124e739131</uuid>
   <memory unit='KiB'>1048576</memory>
   <currentMemory unit='KiB'>1048576</currentMemory>

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -501,6 +501,15 @@ sub _update_isos {
           ,xml_volume => 'wisuvolume.xml'
           ,min_disk_size => '21'
         }
+       ,empty_32bits => {
+          name => 'Empty Machine 32bits'
+          ,description => 'Empty Machine 32bits Boot PXE'
+          ,xml => 'empty-i386.xml'
+          ,xml_volume => 'jessie-volume.xml'
+          ,min_disk_size => '0'
+        }
+
+
     );
 
     $self->_update_table($table, $field, \%data);

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -510,10 +510,10 @@ sub _update_isos {
         }
        ,empty_64bits => {
           name => 'Empty Machine 64bits'
-	 ,description => 'Empty Machine 64bits Boot PXE'
-         ,xml => 'empty-amd64.xml'
-         ,xml_volume => 'jessie-volume.xml'
-	 ,min_disk_size => '0'
+          ,description => 'Empty Machine 64bits Boot PXE'
+          ,xml => 'empty-amd64.xml'
+          ,xml_volume => 'jessie-volume.xml'
+	  ,min_disk_size => '0'
         }
     );
 

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -502,15 +502,15 @@ sub _update_isos {
           ,min_disk_size => '21'
         }
        ,empty_32bits => {
-          name => 'Empty Machine 32bits'
-          ,description => 'Empty Machine 32bits Boot PXE'
+          name => 'Empty Machine 32 bits'
+          ,description => 'Empty Machine 32 bits Boot PXE'
           ,xml => 'empty-i386.xml'
           ,xml_volume => 'jessie-volume.xml'
           ,min_disk_size => '0'
         }
        ,empty_64bits => {
-          name => 'Empty Machine 64bits'
-          ,description => 'Empty Machine 64bits Boot PXE'
+          name => 'Empty Machine 64 bits'
+          ,description => 'Empty Machine 64 bits Boot PXE'
           ,xml => 'empty-amd64.xml'
           ,xml_volume => 'jessie-volume.xml'
           ,min_disk_size => '0'

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -513,7 +513,7 @@ sub _update_isos {
           ,description => 'Empty Machine 64bits Boot PXE'
           ,xml => 'empty-amd64.xml'
           ,xml_volume => 'jessie-volume.xml'
-	  ,min_disk_size => '0'
+          ,min_disk_size => '0'
         }
     );
 

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -508,8 +508,13 @@ sub _update_isos {
           ,xml_volume => 'jessie-volume.xml'
           ,min_disk_size => '0'
         }
-
-
+       ,empty_64bits => {
+          name => 'Empty Machine 64bits'
+	 ,description => 'Empty Machine 64bits Boot PXE'
+         ,xml => 'empty-amd64.xml'
+         ,xml_volume => 'jessie-volume.xml'
+	 ,min_disk_size => '0'
+        }
     );
 
     $self->_update_table($table, $field, \%data);

--- a/templates/ng-templates/new_machine_template.html.ep
+++ b/templates/ng-templates/new_machine_template.html.ep
@@ -163,7 +163,7 @@
       
         <div class="form-group row">
              <input type="submit" class="btn btn-default" name="submit" value="<%=l 'Create' %>"
-                 ng-disabled="new_machineForm.$invalid || (!new_machineForm.id_iso.$viewValue.device && (new_machineForm.iso_file.$modelValue == '<NONE>')) || name_duplicated">
+                 ng-disabled="new_machineForm.$invalid || name_duplicated">
         </div>
     </form>
 </div>


### PR DESCRIPTION
Added definition for empty vm versión 32bits and 64bits.

## Description
Allow create empty machines

## Motivation and Context
The purpose of this request is to provide vm to boot from PXE to connect external provisioning systems.
Fix issue #918
