### PR TITLE
Fix #955 spice

### DIFF
--- a/lib/Ravada/Domain/KVM.pm
+++ b/lib/Ravada/Domain/KVM.pm
@@ -1288,7 +1288,7 @@ sub _set_spice_ip {
     for my $graphics ( $doc->findnodes('/domain/devices/graphics') ) {
         $graphics->setAttribute('listen' => $ip);
 
-        if ( !$self->is_hibernated() ) {
+        if ( !$self->is_hibernated() && !$self->domain->is_active ) {
             my $password;
             if ($set_password) {
                 $password = Ravada::Utils::random_name(4);

--- a/t/kvm/p10_password.t
+++ b/t/kvm/p10_password.t
@@ -301,6 +301,52 @@ sub remove_network_default {
 
 }
 
+sub _remove_network {
+    my $name = shift;
+    my $sth = connector->dbh->prepare(
+        "DELETE FROM networks where name=?"
+    );
+    $sth->execute($name);
+
+}
+# When a domain is started in network that requires password, then
+# the password won't show in password-less networks.
+sub test_reopen {
+    my $vm_name = shift;
+    my $domain1 = create_domain($vm_name);
+
+    add_network_any(1); # with password
+    $domain1->start(user => user_admin
+        ,remote_ip => '8.8.8.8'
+    );
+    my $password1;
+    eval { $password1 = $domain1->spice_password };
+    is($@,'');
+    like($password1,qr'.+');
+
+    my $domain2 = create_domain($vm_name);
+    $domain2->start(user => user_admin
+        ,remote_ip => '127.0.0.1'
+    );
+    my $password2;
+    eval { $password2 = $domain2->spice_password };
+    is($@,'');
+    is($password2,undef);
+
+    $domain1->start(user => user_admin
+        , remote_ip => '127.0.0.1'
+    );
+    my $password1b;
+    eval { $password1b = $domain1->spice_password };
+    is($@,'');
+    like($password1b,qr'.+');
+    is($password1, $password1b);
+
+    $domain1->remove(user_admin);
+    $domain2->remove(user_admin);
+
+    _remove_network('any');
+}
 
 #######################################################
 
@@ -342,6 +388,7 @@ SKIP: {
     is($password,undef,"Expecting no password, got : '".($password or '')."'");
     $domain2->shutdown_now($USER)   if $domain2->is_active;
 
+    test_reopen($vm_name);
     test_domain_no_password($vm_name);
 
     test_any_network_password($vm_name);


### PR DESCRIPTION
Fixes #955
Steps to reproduce:

1. Start virtual machine on network that requires password
2. Start the same virtual machine without stopping it first in a network that doesn't require password
3. Check the password is shown on the browser start screen
