### PR TITLE
#960 - Replaced hardcoded footer with footer variable

### DIFF
--- a/templates/main/list_bases_ng.html.ep
+++ b/templates/main/list_bases_ng.html.ep
@@ -96,7 +96,7 @@
 }
 </style>
 
-%= include 'bootstrap/footer'
+%= include $footer
 %= include 'bootstrap/messages'
 </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I changed the hardcoded footer in list_bases_ng
## Description
<!--- Describe your changes in detail -->
Changed the hardcoded footer from 'bootstrap/footer' to $footer
## Motivation and Context
It is needed so in case there's a custom footer template it shows up instead of the default one.
Solves  #960 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
