### PR TITLE
Fix/1013 hide empty bases

### DIFF
--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -186,9 +186,9 @@ sub list_machines_user {
 
 sub list_machines($self, $user) {
     return $self->list_domains() if $user->can_list_machines();
-    return filter_base_without_clones($self->list_domains()) if $user->can_list_clones();
-    
+
     my @list = ();
+    push @list,(@{filter_base_without_clones($self->list_domains())}) if $user->can_list_clones();
     push @list,(@{$self->list_own_clones($user)}) if $user->can_list_clones_from_own_base();
     push @list,(@{$self->list_own($user)}) if $user->can_list_own_machines();
     

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -185,8 +185,6 @@ sub list_machines_user {
 
 
 sub list_machines($self, $user) {
-    # diag(Dumper(filter_base_without_clones($self->list_domains())));
-    # diag(Dumper($self->list_domains()));
     return $self->list_domains() if $user->can_list_machines();
     return filter_base_without_clones($self->list_domains()) if $user->can_list_clones();
     

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -185,7 +185,10 @@ sub list_machines_user {
 
 
 sub list_machines($self, $user) {
-    return $self->list_domains() if $user->can_list_machines() || $user->can_list_clones();
+    # diag(Dumper(filter_base_without_clones($self->list_domains())));
+    # diag(Dumper($self->list_domains()));
+    return $self->list_domains() if $user->can_list_machines();
+    return filter_base_without_clones($self->list_domains()) if $user->can_list_clones();
     
     my @list = ();
     push @list,(@{$self->list_own_clones($user)}) if $user->can_list_clones_from_own_base();
@@ -312,6 +315,32 @@ sub list_domains($self, %args) {
     $sth->finish;
 
     return \@domains;
+}
+
+=head2 filter_base_without_clones
+
+filters the list of domains and drops all machines that are unacessible and 
+bases with 0 machines accessible
+
+=cut
+
+sub filter_base_without_clones($domains) {
+    my @list;
+    my $size_domains = scalar(@$domains);
+    for (my $i = 0; $i < $size_domains; ++$i) {
+        if (@$domains[$i]->{is_base}) {
+            for (my $j = 0; $j < $size_domains; ++$j) {
+                if ($j != $i && !(@$domains[$j]->{is_base}) && (@$domains[$j]->{id_base} eq @$domains[$i]->{id})) {
+                    push @list, (@$domains[$i]);
+                    last;
+                }
+            }
+        }
+        else {
+            push @list, (@$domains[$i]);
+        }
+    }
+    return \@list;
 }
 
 sub list_own_clones($self, $user) {

--- a/t/user/30_grant_remove.t
+++ b/t/user/30_grant_remove.t
@@ -267,7 +267,7 @@ sub test_list_clones_from_own_base_2 {
 
     for my $m (@$list) {
         is($user->can_manage_machine($m->{id}), 1);
-        next if !exists $m->{id_base};
+        next if $m->{is_base};
 
         my $machine = $vm->search_domain($m->{name});
         eval { $machine->remove($user) };


### PR DESCRIPTION
The grants _clone_all don't show the empty bases, there is a test to check it works property. 

Also the concept of subsets and supersets grants wasn't all correct. 
- _all > _own_machines ; _all > _base_clones ; _all > _clone_all
- but the others aren't supersets for now.

And added a a small changed in test user/30_grant_remove.t, as I understand this was trying to delete a base before the clones and produces a failure. 