### PR TITLE
feature(authentication): Add Attribute to LDAP

### DIFF
--- a/lib/Ravada/Auth/LDAP.pm
+++ b/lib/Ravada/Auth/LDAP.pm
@@ -149,10 +149,17 @@ sub search_user {
 
     $username = escape_filter_value($username);
 
+    my $filter = "($field=$username)";
+    if ( exists $$CONFIG->{ldap}->{filter} ) {
+        my $filter_config = $$CONFIG->{ldap}->{filter};
+        $filter_config = escape_filter_value($filter_config);
+        $filter = "(&($field=$username) ($filter_config))";
+    }
+
     my $mesg = $ldap->search(      # Search for the user
     base   => $base,
     scope  => 'sub',
-    filter => "($field=$username)",
+    filter => $filter,
     typesonly => $typesonly,
     attrs  => ['*']
 


### PR DESCRIPTION
close #1052
Add a LDAP filter for authenticating

Description
Configuration: Filter LDAP and values
Authentication: It enables only LDAP user with that attribute and value

Motivation and Context
Filtering users that are not part of a group but have an attribute that indicates they can log into ravada
