### PR TITLE
Extra options in ldap filter

### DIFF
--- a/lib/Ravada/Auth/LDAP.pm
+++ b/lib/Ravada/Auth/LDAP.pm
@@ -166,7 +166,8 @@ sub search_user {
 
     warn "LDAP retry ".$mesg->code." ".$mesg->error if $retry > 1;
 
-    if ( $retry <= 3 && $mesg->code && $mesg->code != 4 ) {
+    # 89: bad filter
+    if ( $retry <= 3 && $mesg->code && $mesg->code != 4 && $mesg->code != 89) {
          warn "LDAP error ".$mesg->code." ".$mesg->error."."
             ."Retrying ! [$retry]"  if $retry;
          $LDAP_ADMIN = undef;
@@ -180,7 +181,7 @@ sub search_user {
          );
     }
 
-    die "ERROR: ".$mesg->code." : ".$mesg->error
+    die "ERROR: ".$mesg->code." : ".$mesg->error." ".($filter or '')
         if $mesg->code;
 
     return if !$mesg->count();

--- a/lib/Ravada/Auth/LDAP.pm
+++ b/lib/Ravada/Auth/LDAP.pm
@@ -152,8 +152,7 @@ sub search_user {
     my $filter = "($field=$username)";
     if ( exists $$CONFIG->{ldap}->{filter} ) {
         my $filter_config = $$CONFIG->{ldap}->{filter};
-        $filter_config = escape_filter_value($filter_config);
-        $filter = "(&($field=$username) ($filter_config))";
+	$filter = "(&(|($field=$username)) $filter_config)";
     }
 
     my $mesg = $ldap->search(      # Search for the user

--- a/t/README_ldap.md
+++ b/t/README_ldap.md
@@ -5,7 +5,8 @@ You need a LDAP server to run the ldap tests
 ## Install and configure 389-ds
 
 Install this package, when configuring write down the user
-and password of the Directory Manager.
+and password of the Directory Manager. In this example it is
+cn=Directory Manager, password: 12345678
 
     $ sudo apt-get install 389-ds-base
     $ sudo setup-ds
@@ -37,3 +38,13 @@ Example:
       auth: match
       base: 'dc=yournetwork,dc=comorwhatever'
       posix_group: rvd_posix_group
+
+# Run only the ldap tests
+
+Build the source lib dirs and Makefiles
+
+    $ perl Makefile.PL
+
+Run the tests each time you change the source file
+
+    $ make && prove -b t/65*t t/front/60_ldap.t t/front/70_ldap_access.t


### PR DESCRIPTION
You can now create extended filters:
(|(gidNumber=xxx)(gidNumber=xxx)(gidNumber=xxx))

add options #1083
