### PR TITLE
User experience access directly to virtual desktop if only has one machine

### DIFF
--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -1291,6 +1291,11 @@ sub login {
                 , locale => [@languages, @languages2]
             );
 
+            my $machines = $RAVADA->list_machines_user($auth_ok);
+	        #warn Dumper($machines);
+            #warn $machines->[0]->{id} if scalar(@$machines) == 1;
+            $url = "/machine/display/". $machines->[0]->{id_clone}.".vv" if scalar(@$machines) == 1 && $machines->[0]->{id_clone};
+
             $c->session(expiration => $expiration);
             return $c->redirect_to($url);
         } else {

--- a/rvd_front.pl
+++ b/rvd_front.pl
@@ -1292,8 +1292,6 @@ sub login {
             );
 
             my $machines = $RAVADA->list_machines_user($auth_ok);
-	        #warn Dumper($machines);
-            #warn $machines->[0]->{id} if scalar(@$machines) == 1;
             $url = "/machine/display/". $machines->[0]->{id_clone}.".vv" if scalar(@$machines) == 1 && $machines->[0]->{id_clone};
 
             $c->session(expiration => $expiration);


### PR DESCRIPTION
User experience access directly to virtual desktop if only has one machine.

## Description
after login, if there is only one virtual machine for that user, just starts the machine right away.
in order to to avoid unnecessary click stages, and to give a better user experience, it's the biggest request we've ever received.

## Motivation and Context
@eagliardi proposes this issue some days ago.