### PR TITLE
Update development_tools.rst

### DIFF
--- a/docs/devel-docs/development_tools.rst
+++ b/docs/devel-docs/development_tools.rst
@@ -20,7 +20,7 @@ Then we build documentation and host it in `Read the Docs`_ for you.
 .. _Ubuntu: https://www.ubuntu.com/server
 .. _KVM: http://www.linux-kvm.org/
 .. _Spice: https://www.spice-space.org/
-.. _Bootstrap: getbootstrap.com/
+.. _Bootstrap: https://getbootstrap.com/
 .. _AngularJS: https://angularjs.org/
 .. _Transifex: https://www.transifex.com/ravada/ravada/
 .. _Read the Docs: http://readthedocs.org/


### PR DESCRIPTION
In the text: "We use a lot of powerful free source like `GNU`_/Linux `Ubuntu`_, `KVM`_ or `Spice`_, among others. Responsive web made with `Bootstrap`_ and `AngularJS`_."

This url link: `Bootstrap` don't work. <a href=”/UPC/ravada/blob/gh-pages/docs/devel-docs/getbootstrap.com">Bootstrap</a>
Correct: <a href=”https://getbootstrap.com">Bootstrap</a>

