### PR TITLE
fix(docker): latest tag not exist yet

### DIFF
--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - ravada_network
     #image download from dockerhub
-    image: ravada/front
+    image: ravada/front:0.0.2
     #build to build from sources
     #build: dockers/front/.
     restart: unless-stopped
@@ -60,7 +60,7 @@ services:
     networks:
       - ravada_network
     #image download from dockerhub 
-    image: ravada/back
+    image: ravada/back:0.0.2
     #build to build from sources
     #build: dockers/back/.
     privileged: true


### PR DESCRIPTION
If there is no tag defined in docker-compose.yml, it look for the _latest_ default tag.
We have only defined a _0.0.2_ tag.
This solves this situation for now. In the future we will add the _latest_ label that points to the latest version.

Issue #1178 

This PR not merge with develop branch yet. Issue #369 is in WIP status.