### PR TITLE
Added Kali 2020 to the default ISO list

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -456,7 +456,28 @@ sub _update_isos {
             ,xml_volume => 'jessie-volume.xml'
             ,min_disk_size => '10'
         }
-
+        ,kali_64 => {
+            name => 'Kali Linux'
+            ,description => 'Kali Linux 2020 64 Bits'
+            ,arch => 'amd64'
+            ,xml => 'jessie-amd64.xml'
+            ,xml_volume => 'jessie-volume.xml'
+            ,url => 'https://cdimage.kali.org/kali-2020.\d+/'
+            ,file_re => 'kali-linux-2020.\d+-installer-amd64.iso'
+            ,sha256_url => '$url/SHA256SUMS'
+            ,min_disk_size => '10'
+        }
+        ,kali_64_netinst => {
+            name => 'Kali Linux (NetInstaller)'
+            ,description => 'Kali Linux 2020 64 Bits (light NetInstall)'
+            ,arch => 'amd64'
+            ,xml => 'jessie-amd64.xml'
+            ,xml_volume => 'jessie-volume.xml'
+            ,url => 'https://cdimage.kali.org/kali-2020.\d+/'
+            ,file_re => 'kali-linux-2020.\d+-installer-netinst-amd64.iso'
+            ,sha256_url => '$url/SHA256SUMS'
+            ,min_disk_size => '10'
+        }
         ,windows_7 => {
           name => 'Windows 7'
           ,description => 'Windows 7 64 bits. Requires an user provided ISO image.'

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -457,7 +457,7 @@ sub _update_isos {
             ,min_disk_size => '10'
         }
         ,kali_64 => {
-            name => 'Kali Linux'
+            name => 'Kali Linux 2020'
             ,description => 'Kali Linux 2020 64 Bits'
             ,arch => 'amd64'
             ,xml => 'jessie-amd64.xml'
@@ -468,7 +468,7 @@ sub _update_isos {
             ,min_disk_size => '10'
         }
         ,kali_64_netinst => {
-            name => 'Kali Linux (NetInstaller)'
+            name => 'Kali Linux 2020 (NetInstaller)'
             ,description => 'Kali Linux 2020 64 Bits (light NetInstall)'
             ,arch => 'amd64'
             ,xml => 'jessie-amd64.xml'


### PR DESCRIPTION
This patch adds the man Kali installer as well as the lighter net installer to the default ISO list.

The regular expression should suffice for the 2020 releases.
