### PR TITLE
fix(backend): makes ravada handle auto startup

### DIFF
--- a/bin/rvd_back.pl
+++ b/bin/rvd_back.pl
@@ -170,6 +170,7 @@ sub do_start {
     my $t_refresh = 0;
 
     my $ravada = Ravada->new( %CONFIG );
+    autostart_machines($ravada);
     #    Ravada::Request->enforce_limits();
     #Ravada::Request->refresh_vms();
     for (;;) {
@@ -205,6 +206,21 @@ sub done_request {
 sub clean_old_requests {
     my $ravada = Ravada->new( %CONFIG );
     $ravada->clean_old_requests();
+}
+
+sub autostart_machines {
+    my $ravada = shift;
+    for my $domain ( $ravada->list_domains_data ) {
+        next unless $domain->{autostart} && ! $domain->{is_base}
+              && $domain->{status} !~ /active/i;
+
+        print "Auto start $domain->{name} [$domain->{status}]\n" if $VERBOSE;
+
+        Ravada::Request->start_domain(
+            id_domain => $domain->{id}
+            ,uid => $domain->{id_owner}
+        );
+    }
 }
 
 sub start {

--- a/lib/Ravada/Domain/KVM.pm
+++ b/lib/Ravada/Domain/KVM.pm
@@ -2113,7 +2113,9 @@ sub internal_id($self) {
     return $self->domain->get_id();
 }
 
-sub autostart($self, $value=undef, $user=undef) {
+sub autostart { return _internal_autostart(@_) }
+
+sub _internal_autostart($self, $value=undef, $user=undef) {
     $self->domain->set_autostart($value) if defined $value;
     return $self->domain->get_autostart();
 }

--- a/lib/Ravada/Domain/Void.pm
+++ b/lib/Ravada/Domain/Void.pm
@@ -629,7 +629,9 @@ sub is_removed {
     return 1;
 }
 
-sub autostart {
+sub autostart { return _internal_autostart(@_) }
+
+sub _internal_autostart {
     my $self = shift;
     my $value = shift;
 

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -313,7 +313,7 @@ sub list_domains($self, %args) {
             $row->{node} = $domain->_vm->name if $domain->_vm;
             $row->{remote_ip} = $domain->client_status
                 if $domain->client_status && $domain->client_status ne 'connected';
-            $row->{autostart} = $domain->autostart;
+            $row->{autostart} = $domain->_data('autostart');
             if (!$row->{status} ) {
                 if ($row->{is_active}) {
                     $row->{status} = 'active';

--- a/lib/Ravada/VM.pm
+++ b/lib/Ravada/VM.pm
@@ -302,8 +302,8 @@ sub _connect_ssh($self, $disconnect=0) {
     confess "Don't connect to local ssh"
         if $self->is_local;
 
-    if ( $self->readonly ) {
-        warn $self->name." readonly, don't do ssh";
+    if ( $self->readonly || $> ) {
+        confess $self->name." readonly or not root, don't do ssh";
         return;
     }
 

--- a/t/nodes/10_basic.t
+++ b/t/nodes/10_basic.t
@@ -473,6 +473,35 @@ sub test_remove_base($vm, $node, $volatile) {
 
 }
 
+sub _check_internal_autostart($domain, $expected) {
+    if ($domain->type eq 'KVM') {
+        ok($domain->domain->get_autostart)  if $expected;
+        ok(!$domain->domain->get_autostart) if !$expected;
+    } elsif ($domain->type eq 'Void') {
+        ok($domain->_value('autostart'))    if $expected;
+        ok(!$domain->_value('autostart'),$domain->name) or exit   if !$expected;
+    } else {
+        diag("WARNING: I don't know how to check ".$domain->type." internal autostart");
+    }
+}
+
+# check autostart is managed by Ravada when nodes
+sub test_autostart($vm, $node) {
+    my $base = create_domain($vm);
+    $base->prepare_base(user_admin);
+    my $domain = $base->clone(name => new_domain_name , user => user_admin);
+    $domain->autostart(1,user_admin);
+    is($domain->autostart,1);
+    _check_internal_autostart($domain,1);
+
+    $base->set_base_vm(node => $node, user => user_admin);
+    is($domain->autostart,1) or exit;
+    _check_internal_autostart($domain,0);
+
+    $domain->remove(user_admin);
+    $base->remove(user_admin);
+}
+
 ##################################################################################
 clean();
 
@@ -513,6 +542,7 @@ for my $vm_name ( 'Void', 'KVM') {
 
         test_set_vm($vm, $node);
 
+        test_autostart($vm, $node);
         test_volatile($vm, $node);
 
         test_remove_req($vm, $node);


### PR DESCRIPTION
Before we set internal startup. If a machine is in
two nodes it could get started in both nodes.

