### PR TITLE
add tzdata to containers and clarify ravada volume mapping in docker-compose.yml

### DIFF
--- a/dockerfy/.directory
+++ b/dockerfy/.directory
@@ -1,8 +1,0 @@
-[Dolphin]
-Timestamp=2020,5,10,18,1,52
-Version=4
-ViewMode=1
-VisibleRoles=Details_text,Details_size,Details_modificationtime,Details_type,CustomizedDetails
-
-[Settings]
-HiddenFilesShown=true

--- a/dockerfy/.directory
+++ b/dockerfy/.directory
@@ -1,0 +1,8 @@
+[Dolphin]
+Timestamp=2020,5,10,18,1,52
+Version=4
+ViewMode=1
+VisibleRoles=Details_text,Details_size,Details_modificationtime,Details_type,CustomizedDetails
+
+[Settings]
+HiddenFilesShown=true

--- a/dockerfy/.env
+++ b/dockerfy/.env
@@ -7,3 +7,5 @@ MYSQL_PORT=33306
 MYSQL_USER=rvd_user
 MYSQL_PASSWORD=Pword12345*
 MYSQL_MY_DATABASE=ravada
+#modify TZ as required
+TZ=Europe/Athens

--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -4,12 +4,10 @@ services:
     container_name: ravada-mysql
     volumes:
       - "/opt/ravada/mysql:/var/lib/mysql"
-      - "/opt/ravada/log:/var/log/mysql"
       - "/etc/localtime:/etc/localtime:ro"
+      - "/opt/ravada/log:/var/log/mysql"
     networks:
       - ravada_network
-    environment:
-      - TZ=Europe/Madrid #change to your timezone
     image: mysql:5.7
     env_file: .env
     command: --default-authentication-plugin=mysql_native_password
@@ -19,7 +17,6 @@ services:
     container_name: ravada-front
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
-      - "/home/src/ravada:/ravada" #change accordingly and please use absolute path
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
     ports:
       - "3000:3000"
@@ -27,12 +24,11 @@ services:
       - "3000"
     networks:
       - ravada_network
-    environment:
-      - TZ=Europe/Madrid #change to your timezone
+    env_file: .env
     #By default download from dockerhub
-    #image: ravada/front
+    image: ravada/front
     #If you want to local build
-    build: dockers/front/.
+    #build: dockers/front/.
     restart: unless-stopped
 
     depends_on:
@@ -47,18 +43,18 @@ services:
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
       - "/opt/ravada/etc:/etc/libvirt/qemu"
       - "/etc/localtime:/etc/localtime:ro"
-      - "/home/src/ravada:/ravada" #change accordingly and please use absolute path
     ports:
       - "5900-5999:5900-5999"
       - "55900-55999:55900-55999"
     networks:
       - ravada_network
+    env_file: .env
     environment:
-      - TZ=Europe/Madrid #change to your timezone
+      - TZ=Europe/Athens
     #By default download from dockerhub
-    #image: ravada/back
+    image: ravada/back
     #If you want to local build
-    build: dockers/back/.
+    #build: dockers/back/.
     privileged: true
     restart: unless-stopped
 

--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -4,10 +4,12 @@ services:
     container_name: ravada-mysql
     volumes:
       - "/opt/ravada/mysql:/var/lib/mysql"
-      - "/etc/localtime:/etc/localtime:ro"
       - "/opt/ravada/log:/var/log/mysql"
+      - "/etc/localtime:/etc/localtime:ro"
     networks:
       - ravada_network
+    environment:
+      - TZ=Europe/Madrid #change to your timezone
     image: mysql:5.7
     env_file: .env
     command: --default-authentication-plugin=mysql_native_password
@@ -16,9 +18,8 @@ services:
   ravada-front:
     container_name: ravada-front
     volumes:
-      - "/etc/timezone:/etc/timezone:ro"
       - "/etc/localtime:/etc/localtime:ro"
-      - "~/src/ravada:/ravada"
+      - "/home/src/ravada:/ravada" #change accordingly and please use absolute path
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
     ports:
       - "3000:3000"
@@ -26,10 +27,12 @@ services:
       - "3000"
     networks:
       - ravada_network
+    environment:
+      - TZ=Europe/Madrid #change to your timezone
     #By default download from dockerhub
-    image: ravada/front
+    #image: ravada/front
     #If you want to local build
-    #build: dockers/front/.
+    build: dockers/front/.
     restart: unless-stopped
 
     depends_on:
@@ -43,18 +46,19 @@ services:
       - "/opt/ravada/images:/var/lib/libvirt/images"
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
       - "/opt/ravada/etc:/etc/libvirt/qemu"
-      - "/etc/timezone:/etc/timezone:ro"
       - "/etc/localtime:/etc/localtime:ro"
-      - "~/src/ravada:/ravada"
+      - "/home/src/ravada:/ravada" #change accordingly and please use absolute path
     ports:
       - "5900-5999:5900-5999"
       - "55900-55999:55900-55999"
     networks:
       - ravada_network
+    environment:
+      - TZ=Europe/Madrid #change to your timezone
     #By default download from dockerhub
-    image: ravada/back
+    #image: ravada/back
     #If you want to local build
-    #build: dockers/back/.
+    build: dockers/back/.
     privileged: true
     restart: unless-stopped
 

--- a/dockerfy/dockers/back/Dockerfile
+++ b/dockerfy/dockers/back/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:18.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Backend + KVM"
 
-RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
+RUN  apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
     perl libmojolicious-perl libauthen-passphrase-perl \
     libdbd-mysql-perl libdbi-perl libdbix-connector-perl libipc-run3-perl libnet-ldap-perl \
     libproc-pid-file-perl libsys-virt-perl libxml-libxml-perl libconfig-yaml-perl \
@@ -12,7 +12,7 @@ RUN apt-get update \
     libmojolicious-plugin-i18n-perl libdbd-sqlite3-perl debconf adduser libdigest-sha-perl libnet-ssh2-perl \
     libfile-rsync-perl libdate-calc-perl libparallel-forkmanager-perl libdatetime-perl libencode-locale-perl netcat-openbsd \
     liblwp-useragent-determined-perl libvirt-clients supervisor net-tools openssh-client apt-utils curl libpbkdf2-tiny-perl \
-    libio-stringy-perl libvirt-daemon-system libvirt-clients netcat-openbsd qemu-kvm qemu-utils iproute2 wget bridge-utils firewalld dnsmasq iptables ebtables \
+    libio-stringy-perl libvirt-daemon-system libvirt-clients netcat-openbsd qemu-kvm qemu-utils iproute2 wget bridge-utils firewalld dnsmasq iptables ebtables tzdata \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfy/dockers/back/Dockerfile
+++ b/dockerfy/dockers/back/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Backend + KVM"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV RAVADA_BRANCH="develop"
 
 RUN  apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+ &&  apt-get install -y -q --no-install-recommends \
     perl libmojolicious-perl libauthen-passphrase-perl \
     libdbd-mysql-perl libdbi-perl libdbix-connector-perl libipc-run3-perl libnet-ldap-perl \
     libproc-pid-file-perl libsys-virt-perl libxml-libxml-perl libconfig-yaml-perl \
@@ -12,9 +14,23 @@ RUN  apt-get update \
     libmojolicious-plugin-i18n-perl libdbd-sqlite3-perl debconf adduser libdigest-sha-perl libnet-ssh2-perl \
     libfile-rsync-perl libdate-calc-perl libparallel-forkmanager-perl libdatetime-perl libencode-locale-perl netcat-openbsd \
     liblwp-useragent-determined-perl libvirt-clients supervisor net-tools openssh-client apt-utils curl libpbkdf2-tiny-perl \
-    libio-stringy-perl libvirt-daemon-system libvirt-clients netcat-openbsd qemu-kvm qemu-utils iproute2 wget bridge-utils firewalld dnsmasq iptables ebtables tzdata \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    libio-stringy-perl libvirt-daemon-system libvirt-clients netcat-openbsd qemu-kvm qemu-utils iproute2 wget bridge-utils firewalld dnsmasq iptables ebtables \
+    tzdata unzip \
+ && apt-get clean && \
+   echo "**** download ravada files ****" && \
+   mkdir /ravada && \
+   curl -o \
+   /tmp/ravada.zip -L \
+   "https://github.com/UPC/ravada/archive/${RAVADA_BRANCH}.zip" && \
+   unzip /tmp/ravada.zip -d /tmp/ravadatmp && \
+   cp -r /tmp/ravadatmp/ravada-develop/* /ravada && \
+   cp /ravada/dockerfy/dockers/back/network.sh / && \
+   cp /ravada/dockerfy/dockers/back/default.xml / && \
+   cp /ravada/dockerfy/dockers/back/ravada.conf /etc/ && \
+   cp /ravada/dockerfy/dockers/back/supervisord.conf /etc/ \
+ && rm -rf \ 
+   /var/lib/apt/lists/* \
+   /tmp/*
 
 ADD http://infoteleco.upc.edu/img/debian/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb /tmp/
 RUN dpkg -i /tmp/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb \
@@ -26,17 +42,18 @@ RUN dpkg -i /tmp/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb \
 #  && chmod 600 /root/.ssh/config \
  && mkdir -p /var/log/supervisor \
  && mkdir -p /run/sshd
+ 
 
-COPY network.sh default.xml /
+
 
 EXPOSE 5900-5950
 EXPOSE 55900-55950
 
-COPY supervisord.conf /etc/supervisord.conf
+
 
 #RUN mkdir /ravada
 #ADD src/ravada /ravada
-COPY ravada.conf /etc/ravada.conf
+
 WORKDIR /ravada
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/dockerfy/dockers/front/Dockerfile
+++ b/dockerfy/dockers/front/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:18.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Frontend"
 
+
 RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
     perl libmojolicious-perl libauthen-passphrase-perl \
     libdbd-mysql-perl libdbi-perl libdbix-connector-perl libipc-run3-perl libnet-ldap-perl \
     libproc-pid-file-perl libsys-virt-perl libxml-libxml-perl libconfig-yaml-perl \
@@ -11,7 +12,7 @@ RUN apt-get update \
     libio-interface-perl libiptables-chainmgr-perl libnet-dns-perl liblocale-maketext-lexicon-perl \
     libmojolicious-plugin-i18n-perl libdbd-sqlite3-perl debconf adduser libdigest-sha-perl libnet-ssh2-perl libpbkdf2-tiny-perl \
     libfile-rsync-perl libdate-calc-perl libparallel-forkmanager-perl libdatetime-perl libencode-locale-perl netcat-openbsd \
-    libio-stringy-perl libvirt-clients liblwp-useragent-determined-perl supervisor net-tools apt-utils lsof mysql-client \
+    libio-stringy-perl libvirt-clients liblwp-useragent-determined-perl supervisor net-tools apt-utils lsof mysql-client tzdata \
 	curl bash vim wget \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/dockerfy/dockers/front/Dockerfile
+++ b/dockerfy/dockers/front/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:18.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Frontend"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV RAVADA_BRANCH="develop"
 
 
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+ &&  apt-get install -y -q --no-install-recommends \
     perl libmojolicious-perl libauthen-passphrase-perl \
     libdbd-mysql-perl libdbi-perl libdbix-connector-perl libipc-run3-perl libnet-ldap-perl \
     libproc-pid-file-perl libsys-virt-perl libxml-libxml-perl libconfig-yaml-perl \
@@ -12,10 +14,22 @@ RUN apt-get update \
     libio-interface-perl libiptables-chainmgr-perl libnet-dns-perl liblocale-maketext-lexicon-perl \
     libmojolicious-plugin-i18n-perl libdbd-sqlite3-perl debconf adduser libdigest-sha-perl libnet-ssh2-perl libpbkdf2-tiny-perl \
     libfile-rsync-perl libdate-calc-perl libparallel-forkmanager-perl libdatetime-perl libencode-locale-perl netcat-openbsd \
-    libio-stringy-perl libvirt-clients liblwp-useragent-determined-perl supervisor net-tools apt-utils lsof mysql-client tzdata \
+    libio-stringy-perl libvirt-clients liblwp-useragent-determined-perl supervisor net-tools apt-utils lsof mysql-client \
 	curl bash vim wget \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    tzdata unzip \
+ && apt-get clean && \
+   echo "**** download ravada files and copy to directories ****" && \
+   mkdir /ravada && \
+   curl -o \
+   /tmp/ravada.zip -L \
+   "https://github.com/UPC/ravada/archive/${RAVADA_BRANCH}.zip" && \
+   unzip /tmp/ravada.zip -d /tmp/ravadatmp && \
+   cp -r /tmp/ravadatmp/ravada-develop/* /ravada && \
+   cp /ravada/dockerfy/dockers/front/ravada.conf /etc/ && \
+   cp /ravada/dockerfy/dockers/front/supervisord.conf /etc/ \
+ && rm -rf \
+   /var/lib/apt/lists/* \
+   /tmp/*
 
 ADD http://infoteleco.upc.edu/img/debian/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb /tmp/
 RUN dpkg -i /tmp/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb \
@@ -27,9 +41,9 @@ EXPOSE 3000
 
 ENV PERL5LIB /root/local/lib/perl5:/root/lib/:/ravada
 
-COPY supervisord.conf /etc/supervisord.conf
 
-COPY ravada.conf /etc/ravada.conf
+
+
 WORKDIR /ravada
 
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I added tzdata to ravada_front and ravada_back containers to avoid the use of the /etc/timezone mapping.
I changed the relative path of ~/src/ravada to /home/src/ravada and added clarification so that the user changes it to avoid problems such as 
https://github.com/UPC/ravada/issues/1292

The Dockerfiles are configured for local build, UPC should build the new images and then change the Dockerfiles back to pull from DockerHub.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
/etc/timezone is not used in all Linux distributions, so I added the tzdata package to the containers so we can use environment variables in the docker-compose.yml for timezone like image builders such as Linuxserver.io do.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/UPC/ravada/issues/1326