### PR TITLE
refactor: change box position to ask first the current password

### DIFF
--- a/templates/bootstrap/user_settings.html.ep
+++ b/templates/bootstrap/user_settings.html.ep
@@ -45,13 +45,13 @@
 						<h3><%=l 'Change password' %></h3>
                         <form method='post' enctype="multipart/form-data">
                             <div class="from-group row">
+                                <label for="password" class="col-xl-3 col-form-label"><%=l 'Current Password:' %></label><input type='password' name='current_password' id='current_password'>
+                            </div>
+			    <div class="from-group row">
                                 <label for="password" class="col-xl-3 col-form-label"><%=l 'New Password:' %></label><input type= 'password' name= 'password' id='password'>
                             </div>
                             <div class="from-group row">
                                 <label for="password" class="col-xl-3 col-form-label"><%=l 'Confirm Password:' %></label><input type='password' name='conf_password' id='conf_password'>
-                            </div>
-                            <div class="from-group row">
-                                <label for="password" class="col-xl-3 col-form-label"><%=l 'Current Password:' %></label><input type='password' name='current_password' id='current_password'>
                             </div>
 %                           if (scalar @$errors) {
                                     <div class="alert alert-danger mt-2">


### PR DESCRIPTION
Change the box that asks for the current password to the first place, it
was the last box.

Copy the same code and paste it in the first place.

It is not a problem, it is only to be more conventional as other websites.

Issue #1351