### PR TITLE
Fix/1352 check current password

### DIFF
--- a/script/rvd_front
+++ b/script/rvd_front
@@ -1332,27 +1332,36 @@ sub user_settings {
     }
     $c->param('tongue' => $USER->language);
     my @errors;
+    use Data::Dumper;
     if ($c->param('button_click')) {
-        if (($c->param('password') eq "") || ($c->param('conf_password') eq "") || ($c->param('current_password') eq "")) {
-            push @errors,("Some of the password's fields are empty");
-        }
-        else {
-            if ($c->param('password') eq $c->param('conf_password')) {
-                eval {
-                    $USER->change_password($c->param('password'));
-                    _logged_in($c);
-                };
-                if ($@ =~ /Password too small/) {
-                    push @errors,("Password too small")
-                }
-                else {
-                    $changed_pass = 1;
-                }
-            }
-            else {
-                    push @errors,("Password fields aren't equal")
-            }
-        }
+	my $auth_ok;
+        eval { $auth_ok = Ravada::Auth::login($USER->name, $c->param('current_password'))};
+        if (!$auth_ok || $@) {
+		push @errors, ("Current password is wrong");
+	}
+	else {
+
+        	if (($c->param('password') eq "") || ($c->param('conf_password') eq "") || ($c->param('current_password') eq "")) {
+	            push @errors,("Some of the password's fields are empty");
+	        }
+        	else {
+	            if ($c->param('password') eq $c->param('conf_password')) {
+        	        eval {
+                	    $USER->change_password($c->param('password'));
+	                    _logged_in($c);
+        	        };
+	                if ($@ =~ /Password too small/) {
+	                    push @errors,("Password too small")
+	                }
+	                else {
+	                    $changed_pass = 1;
+	                }
+	            }
+	            else {
+	                    push @errors,("Password fields aren't equal")
+	            }
+	        }
+	    }
     }
     $c->render(template => 'bootstrap/user_settings', changed_lang=> $changed_lang, changed_pass => $changed_pass
       ,errors =>\@errors);

--- a/script/rvd_front
+++ b/script/rvd_front
@@ -1332,7 +1332,6 @@ sub user_settings {
     }
     $c->param('tongue' => $USER->language);
     my @errors;
-    use Data::Dumper;
     if ($c->param('button_click')) {
 	my $auth_ok;
         eval { $auth_ok = Ravada::Auth::login($USER->name, $c->param('current_password'))};


### PR DESCRIPTION
Before this change, the form didn't check if the password in the current password field was ok.

To solve this I add some lines that compare the password in the field with the user password. If they don't mach the form shows an error message.

Now the form check if the current password is the real current password.

Fix issue #1352
