### PR TITLE
Improve-doc-cluster_1366 

### DIFF
--- a/docs/docs/nodes.rst
+++ b/docs/docs/nodes.rst
@@ -219,8 +219,8 @@ It means you didn't install libvirt in the node. Fix it this way:
 But now, the libvirt-bin package was dropped in release 18.10 ubuntu. The package was split into two parts:
 
 .. code-block:: bash
-root@node:~# apt-get installlibvirt-daemon-system
-root@node:~# apt-get installlibvirt-clients
+root@node:~# apt-get install libvirt-daemon-system
+root@node:~# apt-get install libvirt-clients
 
 so instead of libvirt-bin you need install libvirt-daemon-system and libvirt-clients.
 

--- a/docs/docs/nodes.rst
+++ b/docs/docs/nodes.rst
@@ -214,8 +214,15 @@ It means you didn't install libvirt in the node. Fix it this way:
 
 .. code-block:: bash
 
-    root@node:~# apt get install libvirt-bin
+    root@node:~# apt-get install libvirt-bin
+    
+But now, the libvirt-bin package was dropped in release 18.10 ubuntu. The package was split into two parts:
 
+.. code-block:: bash
+root@node:~# apt-get installlibvirt-daemon-system
+root@node:~# apt-get installlibvirt-clients
+
+so instead of libvirt-bin you need install libvirt-daemon-system and libvirt-clients.
 
 Balance algorithm
 =================

--- a/docs/docs/nodes.rst
+++ b/docs/docs/nodes.rst
@@ -216,7 +216,7 @@ It means you didn't install libvirt in the node. Fix it this way:
 
     root@node:~# apt-get install libvirt-bin
     
-But now, the libvirt-bin package was dropped in release 18.10 ubuntu. The package was split into two parts:
+But now, the libvirt-bin package was dropped in release 18.10 Ubuntu. The package was split into two parts:
 
 .. code-block:: bash
 root@node:~# apt-get install libvirt-daemon-system


### PR DESCRIPTION
TroubleShooting: libvirt error code: 38, message: End of file while reading data: nc: unix connect failed: No such file or directory
It means you didn’t install libvirt in the node. Fix it this way:
root@node:~# apt get install libvirt-bin

But now, the libvirt-bin package was dropped in release 18.10 ubuntu. The package was split into two parts:
libvirt-daemon-system
libvirt-clients

so instead of libvirt-bin you need install libvirt-daemon-system and libvirt-clients.
