### PR TITLE
fix(docker): port conflict

### DIFF
--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -47,7 +47,9 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "~/src/ravada:/ravada"
     ports:
-      - "5900-5999:5900-5999"
+      - "5900-5938:5900-5938"
+    #Unexposed 5939 Teamviewer port
+      - "5940-5999:5940-5999"
       - "55900-55999:55900-55999"
     networks:
       - ravada_network

--- a/dockerfy/dockers/back/Dockerfile
+++ b/dockerfy/dockers/back/Dockerfile
@@ -29,7 +29,8 @@ RUN dpkg -i /tmp/libmojolicious-plugin-renderfile-perl_0.10-1_all.deb \
 
 COPY network.sh default.xml /
 
-EXPOSE 5900-5950
+EXPOSE 5900-5938
+EXPOSE 5940-5950
 EXPOSE 55900-55950
 
 COPY supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
Unexposed 5939 teamviewer port

Issue #1328

From @sotiris-bos's issue. The 5939 port is unexposed and doesn't cause conflict with Teamviewer.
