### PR TITLE
Update bootstrap-select version

### DIFF
--- a/etc/fallback.conf
+++ b/etc/fallback.conf
@@ -7,7 +7,7 @@ https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js
 https://code.angularjs.org/1.7.8/angular-1.7.8.zip
 https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.5.0/ui-bootstrap.min.js
 https://cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js raphael.js/
-https://github.com/snapappointments/bootstrap-select/archive/v1.13.9.zip
+https://github.com/snapappointments/bootstrap-select/archive/v1.13.15.zip
 https://cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js morris.js/
 https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.7.0/intro.js intro.js/
 https://github.com/twbs/bootstrap/releases/download/v4.3.1/bootstrap-4.3.1-dist.zip

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "angular-sanitize": "1.5.5",
     "bootstrap": ">=4.3.1",
     "popper": "1.0.1",
-     "bootstrap-select": "1.12.2",
+     "bootstrap-select": "1.13.15",
     "ckeditor": ">=4.11.0",
     "font-awesome5": "^1.0.5",
     "intro.js": "2.7.0",

--- a/templates/bootstrap/header.html.ep
+++ b/templates/bootstrap/header.html.ep
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.css">
 	<link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.7/css/bootstrap-select.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.15/css/bootstrap-select.css">
     <link href="https://use.fontawesome.com/releases/v5.0.7/css/all.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.7.0/introjs.css" rel="stylesheet" type="text/css">
     <script src="https://cdn.ckeditor.com/4.11.3/standard/ckeditor.js"></script>
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/fallback/morris.js/morris.css">
     <link rel="stylesheet" href="/fallback/bootstrap-4.3.1-dist/css/bootstrap.min.css" type="text/css">
 
-    <link rel="stylesheet" href="/fallback/bootstrap-select-1.13.9/dist/css/bootstrap-select.css" type="text/css">
+    <link rel="stylesheet" href="/fallback/bootstrap-select-1.13.15/dist/css/bootstrap-select.css" type="text/css">
     <link rel="stylesheet" href="/fallback/fontawesome-free-5.10.1-web/css/all.css" type="text/css">
     <link rel="stylesheet" href="/fallback/intro.js/bin/introjs.css" type="text/css">
     <script src="/fallback/ckeditor/ckeditor.js"></script>

--- a/templates/bootstrap/scripts.html.ep
+++ b/templates/bootstrap/scripts.html.ep
@@ -16,7 +16,7 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.0/raphael-min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/morris.js/0.5.1/morris.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.7/js/bootstrap-select.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.15/js/bootstrap-select.js"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.7.0/intro.js"></script>
 
@@ -37,7 +37,7 @@
 <script src="/fallback/raphael.js/raphael-min.js"></script>
 <script src="/fallback/morris.js/morris.min.js"></script>
 
-<script src="/fallback/bootstrap-select-1.13.9/dist/js/bootstrap-select.js"></script>
+<script src="/fallback/bootstrap-select-1.13.15/dist/js/bootstrap-select.js"></script>
 
 <script src="/fallback/intro.js/intro.js"></script>
 % }


### PR DESCRIPTION
Incompatible use of jquery 3.5.0 version with bootstrap-select 1.13.7 version.

The error is solved upgrading bootstrap-select version to 1.13.15

Fixes #1364 
