### PR TITLE
modified docker files for tzdata package compatibility

### DIFF
--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: ravada-mysql
     volumes:
       - "/opt/ravada/mysql:/var/lib/mysql"
-      - "/etc/localtime:/etc/localtime:ro"
+      #- "/etc/localtime:/etc/localtime:ro"
       - "/opt/ravada/log:/var/log/mysql"
     networks:
       - ravada_network
@@ -16,8 +16,8 @@ services:
   ravada-front:
     container_name: ravada-front
     volumes:
-      - "/etc/timezone:/etc/timezone:ro"
-      - "/etc/localtime:/etc/localtime:ro"
+      #- "/etc/timezone:/etc/timezone:ro"
+      #- "/etc/localtime:/etc/localtime:ro"
       - "~/src/ravada:/ravada"
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
     ports:
@@ -27,9 +27,9 @@ services:
     networks:
       - ravada_network
     #By default download from dockerhub
-    image: ravada/front
+    #image: ravada/front
     #If you want to local build
-    #build: dockers/front/.
+    build: dockers/front/.
     restart: unless-stopped
 
     depends_on:
@@ -43,20 +43,20 @@ services:
       - "/opt/ravada/images:/var/lib/libvirt/images"
       - "/opt/ravada/screenshots:/var/www/img/screenshots"
       - "/opt/ravada/etc:/etc/libvirt/qemu"
-      - "/etc/timezone:/etc/timezone:ro"
-      - "/etc/localtime:/etc/localtime:ro"
+      #- "/etc/timezone:/etc/timezone:ro"
+      #- "/etc/localtime:/etc/localtime:ro"
       - "~/src/ravada:/ravada"
     ports:
-      - "5900-5938:5900-5938"
+      #- "5900-5938:5900-5938"
     #Unexposed 5939 Teamviewer port
       - "5940-5999:5940-5999"
       - "55900-55999:55900-55999"
     networks:
       - ravada_network
     #By default download from dockerhub
-    image: ravada/back
+    #image: ravada/back
     #If you want to local build
-    #build: dockers/back/.
+    build: dockers/back/.
     privileged: true
     restart: unless-stopped
 

--- a/dockerfy/dockers/back/Dockerfile
+++ b/dockerfy/dockers/back/Dockerfile
@@ -14,7 +14,10 @@ RUN apt-get update \
     liblwp-useragent-determined-perl libvirt-clients supervisor net-tools openssh-client apt-utils curl libpbkdf2-tiny-perl \
     libio-stringy-perl libvirt-daemon-system libvirt-clients netcat-openbsd qemu-kvm qemu-utils iproute2 wget bridge-utils firewalld dnsmasq iptables ebtables \
     libnet-openssh-perl libdatetime-format-dateparse-perl \
- && apt-get clean \
+ && apt-get clean
+
+ENV TZ=Europe/Madrid
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata \
  && rm -rf /var/lib/apt/lists/*
 
 RUN echo "listen_tls = 0" >> /etc/libvirt/libvirtd.conf \

--- a/dockerfy/dockers/front/Dockerfile
+++ b/dockerfy/dockers/front/Dockerfile
@@ -13,8 +13,12 @@ RUN apt-get update \
     libfile-rsync-perl libdate-calc-perl libparallel-forkmanager-perl libdatetime-perl libencode-locale-perl netcat-openbsd \
     libio-stringy-perl libvirt-clients liblwp-useragent-determined-perl supervisor net-tools apt-utils lsof mysql-client \
 	curl bash vim wget libnet-openssh-perl libdatetime-format-dateparse-perl \
- && apt-get clean \
+ && apt-get clean
+
+ENV TZ=Europe/Madrid
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata \
  && rm -rf /var/lib/apt/lists/*
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN mkdir -p /var/log/supervisor \
  && mkdir -p /run/sshd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
volume /etc/timezone and /etc/localtime mounting disabled and replaced by installing the tzdata package on docker back and front image to facilitate execution on OSX system that does not allow mounting the volume /etc

The timezone can be configured using variable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ravada integration with OSX systems
<!--- If it fixes an open issue, please link to the issue here. -->