### PR TITLE
Fix backingstore

### DIFF
--- a/lib/Ravada/Domain/KVM.pm
+++ b/lib/Ravada/Domain/KVM.pm
@@ -510,15 +510,24 @@ sub _set_volumes_backing_store($self) {
         for my $source( $disk->findnodes('source')) {
             my $file = $source->getAttribute('file');
             my $backing_file = $vol{$file}->backing_file();
-            my $backing_file_format = $vol{$file}->_qemu_info('backing file format');
+
 
             my ($backing_store) = $disk->findnodes('backingStore');
             if ($backing_file) {
+                my $vol_backing_file = Ravada::Volume->new(
+                    file => $backing_file
+                    ,vm => $self->_vm
+                );
+                my $backing_file_format = (
+                    $vol_backing_file->_qemu_info('file format')
+                        or 'qcow2'
+                );
+
                 $backing_store = $disk->addNewChild(undef,'backingStore') if !$backing_store;
                 $backing_store->setAttribute('type' => 'file');
 
-                my $format = $backing_store->findnodes('format');
-                $format = $backing_store->addNewChild(undef,'format');
+                my ($format) = $backing_store->findnodes('format');
+                $format = $backing_store->addNewChild(undef,'format') if !$format;
                 $format->setAttribute('type' => $backing_file_format);
 
                 my ($source_bf) = $backing_store->findnodes('source');

--- a/t/vm/45_vol_swap.t
+++ b/t/vm/45_vol_swap.t
@@ -91,9 +91,10 @@ sub test_clone_raw($domain ) {
         is($format->getAttribute('type'),'qcow2',"Expecting format ".$format->toString)
             or exit;
     }
-    is($found,2) or exit;
+    is($found,2);
 
-    $clone->start(user_admin);
+    eval { $clone->start(user_admin) };
+    is(''.$@,'',"starting ".$clone->name) or exit;
     is($clone->is_active,1);
     $clone->remove(user_admin);
 }


### PR DESCRIPTION
Checks the real storage format so it is added to the machine definition as required for the new libvirt release.

Closes issue #1324 and issue #1385 