### PR TITLE
Save LDAP errors in $ldap_err to reduce noise in logs

### DIFF
--- a/lib/Ravada/Auth.pm
+++ b/lib/Ravada/Auth.pm
@@ -24,7 +24,7 @@ sub init {
     if ($config->{ldap}) {
         eval {
             require Ravada::Auth::LDAP;
-            Ravada::Auth::LDAP::init($config); 
+            Ravada::Auth::LDAP::init($config);
             $LDAP_OK = 1;
         };
         warn $@ if $@;
@@ -45,17 +45,22 @@ Tries login in all the submodules
 sub login {
     my ($name, $pass, $quiet) = @_;
 
-    my $login_ok;
+    my ($login_ok, $ldap_err);
     if (!defined $LDAP_OK || $LDAP_OK) {
         eval {
             $login_ok = Ravada::Auth::LDAP->new(name => $name, password => $pass);
         };
-        warn $@ if $@ && $LDAP_OK && !$quiet;
+        $ldap_err = $@ if $@ && $LDAP_OK && !$quiet;
         if ( $login_ok ) {
+            warn $ldap_err if $ldap_err && $LDAP_OK && !$quiet;
             return $login_ok;
         }
     }
-    return Ravada::Auth::SQL->new(name => $name, password => $pass);
+    my $sql_login = Ravada::Auth::SQL->new(name => $name, password => $pass);
+    unless ($sql_login) {
+        warn $ldap_err if $ldap_err && $LDAP_OK && !$quiet;
+    }
+    return $sql_login;
 }
 
 =head2 enable_LDAP


### PR DESCRIPTION
This fixes https://github.com/UPC/ravada/issues/1377:

  When there is LDAP auth configured in the server but SQL users login
  there is a warning in the logs:

    ERROR: Login failed 'carlos' at
    /usr/share/perl5/Ravada/Auth/LDAP.pm line 62.

  The user logs in and everything works as expected, this is a cosmetic
  problem of noise in the log file.

---

```
|   | LDAP | SQL |                                              |
|---+------+-----+----------------------------------------------|
| 1 | p    | p   | can't happen, if LDAP passes we return early |
| 2 | p    | f   | if LDAP passes we return early               |
| 3 | f    | p   | nothing is printed because SQL passed        |
| 4 | f    | f   | auth error should be printed                 |
```
We had to fix the 4th case, this'll fix it by checking for Auth::SQL
first. Also, now `LDAP' & `SQL' column will swap in above matrix to
become:
```
|   | SQL | LDAP |                                              |
|---+-----+------+----------------------------------------------|
| 1 | p   | p    | can't happen, if SQL passes we return early  |
| 2 | f   | p    | LDAP will return if it passes                |
| 3 | p   | f    | early return on SQL pass                     |
| 4 | f   | f    | auth error will be printed                   |
```
All the four cases look good now & the errors are also printed on
failures.

<!--- Provide a general summary of your changes in the Title above -->
