### PR TITLE
Fix sync clones back

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -4394,6 +4394,12 @@ sub _cmd_open_exposed_ports($self, $request) {
     $domain->open_exposed_ports();
 }
 
+=head2 set_debug_value
+
+Sets debug global variable from setting
+
+=cut
+
 sub set_debug_value($self) {
 	$DEBUG = $self->setting('backend/debug'); 
 }

--- a/lib/Ravada/Domain.pm
+++ b/lib/Ravada/Domain.pm
@@ -38,7 +38,7 @@ our %PROPAGATE_FIELD = map { $_ => 1} qw( run_timeout shutdown_disconnected);
 our $TIME_CACHE_NETSTAT = 60; # seconds to cache netstat data output
 our $RETRY_SET_TIME=10;
 
-our $DEBUG_RSYNC = 1;
+our $DEBUG_RSYNC = 0;
 
 _init_connector();
 
@@ -2815,6 +2815,7 @@ sub _open_exposed_port($self, $internal_port, $name, $restricted) {
 
 sub _open_iptables_state($self) {
     my $local_net = $self->ip;
+    return if !$local_net;
     $local_net =~ s{(.*)\.\d+}{$1.0/24};
 
     $self->_vm->iptables_unique(
@@ -3960,7 +3961,7 @@ sub rsync($self, @args) {
         }
         my $msg = $self->_msg_log_rsync($file, $node, "rsync", $request);
 
-        $request->status("syncinc",$msg) if $request;
+        $request->status("syncing",$msg) if $request;
         warn "$msg\n" if $DEBUG_RSYNC;
 
         my $t0 = time;
@@ -3992,7 +3993,7 @@ sub _rsync_volumes_back($self, $node, $request=undef) {
 
         my $msg = $self->_msg_log_rsync($file, $node, "rsync_back", $request);
 
-        $request->status("syncinc",$msg) if $request;
+        $request->status("syncing",$msg) if $request;
         warn "$msg\n" if $DEBUG_RSYNC;
         my $t0 = time;
         $rsync->exec(src => 'root@'.$node->host.":".$file ,dest => $file );
@@ -5225,7 +5226,7 @@ sub list_instances($self) {
     return @instances;
 }
 
-=head2 has_shared_storage
+=head2 has_non_shared_storage
 
 Return wether this virtual machine has non shared storage volumes
 

--- a/t/kvm/n10_nodes.t
+++ b/t/kvm/n10_nodes.t
@@ -725,11 +725,12 @@ sub test_clone_not_in_node {
     $domain->prepare_base(user_admin);
     is($domain->base_in_vm($vm->id), 1);
     $domain->set_base_vm(vm => $node, user => user_admin);
+    wait_request(debug => 1);
 
     is($domain->base_in_vm($node->id), 1);
 
     my @clones;
-    for ( 1 .. 4 ) {
+    for ( 1 .. 10 ) {
         my $clone1 = $domain->clone(name => new_domain_name, user => user_admin);
         push @clones,($clone1);
         is($clone1->_vm->host, 'localhost');
@@ -941,6 +942,8 @@ sub test_sync_back($node) {
     }
 
     _shutdown_nicely($clone);
+    fast_forward_requests();
+    wait_request();
     is ( $clone->is_active, 0 );
     for my $file ($clone->list_volumes) {
         my $md5 = _md5($file, $vm);
@@ -1153,6 +1156,10 @@ SKIP: {
         remove_node($node);
         next;
     };
+
+    # remove
+    test_clone_not_in_node($vm_name, $node);
+
     is($node->is_local,0,"Expecting ".$node->name." ".$node->ip." is remote" ) or BAIL_OUT();
     test_already_started_hibernated($vm_name, $node);
 
@@ -1167,7 +1174,6 @@ SKIP: {
     test_remove_base_main($node);
     test_status($node);
     test_bases_node($vm_name, $node);
-    test_clone_not_in_node($vm_name, $node);
     test_clone_make_base($vm_name, $node);
 
     test_migrate_back($node);

--- a/t/lib/Test/Ravada.pm
+++ b/t/lib/Test/Ravada.pm
@@ -30,7 +30,7 @@ require Exporter;
 
 @ISA = qw(Exporter);
 
-@EXPORT = qw(base_domain_name new_domain_name rvd_back remove_old_disks remove_old_domains create_user user_admin wait_request rvd_front init init_vm clean new_pool_name new_volume_name
+@EXPORT = qw(base_domain_name new_domain_name rvd_back remove_old_disks remove_old_domains create_user user_admin rvd_front init init_vm clean new_pool_name new_volume_name
 create_domain
     import_domain
     test_chain_prerouting
@@ -60,7 +60,9 @@ create_domain
     create_storage_pool
     local_ips
 
+    wait_request
     delete_request
+    fast_forward_requests
 
     remove_old_domains_req
     mojo_init
@@ -876,6 +878,19 @@ sub wait_request {
         return if defined $timeout && time - $t0 >= $timeout;
         sleep 1 if $background;
     }
+}
+
+=head2 fast_forward_requests
+
+Sets scheduled requests time to now
+
+=cut
+
+sub fast_forward_requests() {
+    my $sth = $CONNECTOR->dbh->prepare("UPDATE requests "
+        ." SET at_time=0 WHERE status = 'requested' AND at_time>0 "
+    );
+    $sth->execute();
 }
 
 sub init_vm {

--- a/t/nodes/10_basic.t
+++ b/t/nodes/10_basic.t
@@ -1100,6 +1100,8 @@ sub test_migrate($vm, $node) {
     is($domain3->_data('id_vm'), $node->id);
     is($domain3->_vm->id, $node->id);
 
+    is($domain3->has_non_shared_storage($vm),1) or exit;
+
     $domain->remove(user_admin);
 }
 


### PR DESCRIPTION
In some environments, nodes may be disposable hardware and may not be available later.
When shutting down remote domains on non-shared storage we need the changes back. We schedule a low priority request to do so later.