### PR TITLE
Refactor/1389 shutdown clones

### DIFF
--- a/lib/Ravada/I18N/en.po
+++ b/lib/Ravada/I18N/en.po
@@ -866,3 +866,15 @@ msgstr ""
 
 msgid "Add description"
 msgstr ""
+
+msgid "These actions affect all the clones on the machine"
+msgstr ""
+
+msgid "Shutdown all clones"
+msgstr ""
+
+msgid "Keep in mind that there may be users using a clone"
+msgstr ""
+
+msgid "Yes, shutwdown all the clones"
+msgstr ""

--- a/templates/main/vm_clones.html.ep
+++ b/templates/main/vm_clones.html.ep
@@ -11,7 +11,7 @@
             <button class="btn btn-danger" id="shutdown-clones" name="shutdown-clones"
                 ng-click="shutdown_clones=1"
             >
-                <%=l 'Close all clones' %>
+                <%=l 'Shutdown all clones' %>
             </button>
         </div>
         <div ng-show="shutdown_clones">

--- a/templates/main/vm_clones.html.ep
+++ b/templates/main/vm_clones.html.ep
@@ -21,7 +21,7 @@
                         <a type="button" class="btn btn-primary text-white"
                             ng-click="shutdown_clones=0"
                         ><%=l 'No' %></a>
-                        <a type="button" class="btn btn-danger text-white" ng-click="request('shutdown_clones',{ 'id_domain': showmachine.id });"
+                        <a type="button" class="btn btn-danger text-white" ng-click="request('shutdown_clones',{ 'id_domain': showmachine.id });shutdown_clones=0"
                         ><%=l 'Yes, shutwdown all the clones' %></a>
            </div>
 


### PR DESCRIPTION
The shutdown clones screen from the machine options work but has some glitches in the user interface.

￼ Change "close all clones" for "shutdown all clones"
￼ The confirm dialog should be hidden once the action is requested.