### PR TITLE
Feature/1419 chatwoot

### DIFF
--- a/etc/rvd_front.conf.example
+++ b/etc/rvd_front.conf.example
@@ -37,4 +37,7 @@
       ,file => '/var/log/ravada/rvd_front.log'
       ,level => 'debug'
   }
+# Insert widget in /js/custom/insert_here_widget.js
+# this widget embed js in templates/bootstrap/scripts.html.ep
+  ,widget => ''
 };

--- a/script/rvd_front
+++ b/script/rvd_front
@@ -66,7 +66,7 @@ my $CONFIG_FRONT = plugin Config => { default => {
                                               ,monitoring => 0
                                               ,fallback => 0
                                               ,guide_custom => ''
-                                              ,widget_footer => ''
+                                              ,widget => ''
                                               ,admin => {
                                                     hide_clones => 15
                                                     ,autostart => 0
@@ -156,7 +156,7 @@ hook before_routes => sub {
             ,check_netdata => 0
             ,guide => $CONFIG_FRONT->{guide}
             ,host => $host
-            ,widget_footer => $CONFIG_FRONT->{widget_footer}
+            ,widget => $CONFIG_FRONT->{widget}
             );
 
     $USER = _logged_in($c);

--- a/script/rvd_front
+++ b/script/rvd_front
@@ -66,6 +66,7 @@ my $CONFIG_FRONT = plugin Config => { default => {
                                               ,monitoring => 0
                                               ,fallback => 0
                                               ,guide_custom => ''
+                                              ,widget_footer => ''
                                               ,admin => {
                                                     hide_clones => 15
                                                     ,autostart => 0
@@ -155,6 +156,7 @@ hook before_routes => sub {
             ,check_netdata => 0
             ,guide => $CONFIG_FRONT->{guide}
             ,host => $host
+            ,widget_footer => $CONFIG_FRONT->{widget_footer}
             );
 
     $USER = _logged_in($c);

--- a/templates/bootstrap/scripts.html.ep
+++ b/templates/bootstrap/scripts.html.ep
@@ -62,3 +62,4 @@
         document.getElementById("spinn"+iD).style.display="none";
     }
 </script>
+<script src="<%= $widget_footer %>"></script>

--- a/templates/bootstrap/scripts.html.ep
+++ b/templates/bootstrap/scripts.html.ep
@@ -62,4 +62,7 @@
         document.getElementById("spinn"+iD).style.display="none";
     }
 </script>
-<script src="<%= $widget_footer %>"></script>
+
+% if ( $widget ) {
+<script src="<%= $widget %>"></script>
+% }


### PR DESCRIPTION
We need to provide a better way to embed a widget in `scripts.html.ep`. 
This widget is defined in `/etc/rvd_front.conf` as a `widget` variable.
In our example with Chatwoot, for example, we copy the widget in `chatwoot.js` file,  stored in `public/js/custom/chatwoot.js` and defined in `/etc/rvd_front.conf` as `widget=>'/js/custom/chatwoot.js'`
This way is a better option and support futures Ravada upgrades.
The initial solution was hardcoded the widget in the code.