### PR TITLE
.getQueryStringFromObject fails in Firefox. Changes '' reference to '…

### DIFF
--- a/public/js/ravada.js
+++ b/public/js/ravada.js
@@ -222,7 +222,7 @@
             };
 
             $scope.action = function(target,action,machineId,params){
-              $http.get('/'+target+'/'+action+'/'+machineId+'.json'+'?'+$scope.getQueryStringFromObject(params))
+              $http.get('/'+target+'/'+action+'/'+machineId+'.json'+'?'+this.getQueryStringFromObject(params))
                 .then(function() {
                 }, function(data,status) {
                       console.error('Repos error', status, data);


### PR DESCRIPTION
$scope.getQueryStringFromObject fails in Firefox. Changes '$scope' reference to 'this' should fix it