### PR TITLE
[FIX] doc install from dockers

### DIFF
--- a/docs/docs/INSTALLfromDockers.rst
+++ b/docs/docs/INSTALLfromDockers.rst
@@ -51,7 +51,8 @@ Follow this steps:
 
    cd ~
    mkdir src
-   git clone https://github.com/UPC/ravada.git src/
+   cd src/
+   git clone https://github.com/UPC/ravada.git 
    cd ravada/dockerfy
    
 .. prompt:: bash $

--- a/docs/docs/INSTALLfromDockers.rst
+++ b/docs/docs/INSTALLfromDockers.rst
@@ -51,7 +51,7 @@ Follow this steps:
 
    cd ~
    mkdir src
-   git clone https://github.com/UPC/ravada.git
+   git clone https://github.com/UPC/ravada.git src/
    cd ravada/dockerfy
    
 .. prompt:: bash $


### PR DESCRIPTION

## Description
As per docs is not totally clear that the Git repo must be cloned within `~/src/` directory.

## Motivation and Context
If this is not done admins will face the `No such file or directory` error as per the [Dockers Troubleshoots](https://ravada.readthedocs.io/en/latest/docs/INSTALLfromDockers.html#dockers-troubleshoots) 

