### PR TITLE
Simplify the KVM virsh console access command

### DIFF
--- a/docs/docs/config_console.rst
+++ b/docs/docs/config_console.rst
@@ -6,8 +6,7 @@ From Debian / Ubuntu guest
 
 .. prompt:: bash
 
-    sudo systemctl enable serial-getty@ttyS0.service
-    sudo systemctl start serial-getty@ttyS0.service
+    sudo systemctl enable --now serial-getty@ttyS0.service
 
 From KVM server
 ---------------


### PR DESCRIPTION
## Description
Previosly two commands are run; the first enables it for every start; the second start's it.
systemctl has a option at `enable` and `disable` that allows to start or stop it directly without a second command

```bash
$ systemctl --help | grep now                                              
     --now               Start or stop unit after enabling or disabling it
```

## Motivation and Context
It simplifies the command the user has to run. one command is easier as two's.