### PR TITLE
refactor: clean only automatic shutdowns

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -4164,8 +4164,10 @@ sub _refresh_down_domains($self, $active_domain, $active_vm) {
 sub _remove_unnecessary_downs($self, $domain) {
 
         my @requests = $domain->list_requests(1);
+        my $uid_daemon = Ravada::Utils::user_daemon->id();
         for my $req (@requests) {
-            $req->status('done') if $req->command =~ /shutdown/ && !$req->at_time;
+            $req->status('done') if $req->command =~ /shutdown/
+            && (!$req->at_time || $req->defined_arg('uid') == $uid_daemon );
             $req->_remove_messages();
         }
 }

--- a/lib/Ravada/Domain.pm
+++ b/lib/Ravada/Domain.pm
@@ -2553,7 +2553,7 @@ sub _post_shutdown {
         my $req = Ravada::Request->force_shutdown_domain(
             id_domain => $self->id
                ,id_vm => $self->_vm->id
-                , uid => $arg{user}->id
+                , uid => Ravada::Utils::user_daemon->id
                  , at => time+$timeout
         );
     }

--- a/t/vm/10_domain.t
+++ b/t/vm/10_domain.t
@@ -283,6 +283,9 @@ sub test_shutdown {
 
     my @reqs = $domain->list_requests(1);
     ok(scalar @reqs,$domain->name);
+    my @req_shutdown = grep { $_->command eq 'force_shutdown' } @reqs;
+    is(scalar(@req_shutdown),1)
+    and is($req_shutdown[0]->defined_arg('uid'), Ravada::Utils::user_daemon->id);
 
     $domain->shutdown_now(user_admin);
 
@@ -296,7 +299,7 @@ sub test_shutdown {
     my @req_other = grep { $_->command ne 'refresh_machine' } @reqs;
     is(scalar(@req_other),0);
 
-    is(scalar @reqs,1,$domain->name) or die Dumper([ map { [$_->id,$_->command,$_->status,$_->error] } @reqs]);
+    is(scalar @reqs,1,$domain->name) or die Dumper([ map { [$_->id,$_->command,$_->defined_arg('uid'),$_->status,$_->error] } @reqs]);
 
     $domain->remove(user_admin);
 }


### PR DESCRIPTION
Shutdowns can be programmed since #1533, but only automatic shutdowns should be removed on startup.
