### PR TITLE
Remove hardcoded strings

### DIFF
--- a/templates/main/admin_group.html.ep
+++ b/templates/main/admin_group.html.ep
@@ -31,12 +31,17 @@
                     >
                     </select>
                     <button ng-show="new_member && new_member.name"
-                        ng-click="add_member(new_member.name)">Add</button>
+                            ng-click="add_member(new_member.name)">
+                      <%=l 'Add' %>
+                    </button>
                 </div>
 
                 <div ng-show="!removed">
                 <div class="alert alert-danger" ng-show="error">{{error}}</div>
-                <div class="alert alert-warning" ng-show="!error && group_members.length==0">No members found</div>
+                <div class="alert alert-warning"
+                     ng-show="!error && group_members.length==0">
+                  <%=l 'No members found' %>
+                </div>
                 </div>
 
                 <table class="table table-striped" ng-show="group_members.length>0">

--- a/templates/main/admin_groups.html.ep
+++ b/templates/main/admin_groups.html.ep
@@ -52,7 +52,7 @@
                             </tbody>
                     </table>
                     <div ng-show="ldap_groups.length == 0">
-                        No groups found
+                      <%=l 'No groups found' %>
                     </div>
                 </div>
               </div>

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -194,12 +194,14 @@
                                </div>
                                <div class="modal-body" ng-show="can_prepare_base(machine)">
                                    <div ng-show="machine.info.cdrom">
-                                   <p>This machine has a CD-ROM</p>
-                                   <ul>
+                                     <p>
+                                     <%=l 'This machine has a CD-ROM' %>
+                                     </p>
+                                     <ul>
                                        <li ng-repeat="cdrom in machine.info.cdrom">{{cdrom}}</li>
-                                   </ul>
-                                   <input type="checkbox" ng-model="with_cd" name="with_cd"/>
-                                    <label for="with_cd"><%=l 'Keep the CD for the clones' %></label>
+                                     </ul>
+                                     <input type="checkbox" ng-model="with_cd" name="with_cd"/>
+                                     <label for="with_cd"><%=l 'Keep the CD for the clones' %></label>
                                    </div>
                                  <p><%=l 'Are you sure you want to prepare the base of' %> {{machine.name}}?</p>
                                </div>
@@ -218,7 +220,7 @@
                         <input type="checkbox" checked ng-show="machine.is_public" ng-click="open_modal('mp_',machine)" title="<%=l 'Make private'%>" ng-cloak>
 
                          <input type="checkbox" ng-hide="!machine.is_base || machine.is_public" ng-click="open_modal('mp_',machine)" title="<%=l 'Make public' %>" ng-cloak>
-                       
+
                         <div class="modal fade" tabindex="-1" role="dialog" id="mp_{{machine.id}}">
                            <div class="modal-dialog" role="document">
                              <div class="modal-content">
@@ -238,7 +240,7 @@
                          </div>
                        </td>
 
-                         
+
 %                       if ($autostart) {
                             <td class="lgMachToggle">
 				    <input type="checkbox" ng-hide="machine.has_clones || machine.is_base" ng-model="machine.autostart" ng-true-value="1" ng-false-value="0" ng-change="set_autostart(machine.id,machine.autostart)" title="{{ machine.autostart ? 'Disable' : 'Enable'}} autostart">

--- a/templates/main/admin_settings.html.ep
+++ b/templates/main/admin_settings.html.ep
@@ -188,7 +188,9 @@
                     save
                 </button>
                 <button ng-click="load_settings()"
-                    ng-disabled="formSettings.$pristine">cancel</button>
+                        ng-disabled="formSettings.$pristine">
+                  <%=l 'cancel' %>
+                </button>
             </div>
         </div>
 

--- a/templates/main/machine_access_client_verify.html.ep
+++ b/templates/main/machine_access_client_verify.html.ep
@@ -1,7 +1,9 @@
 <div class="card alert-info" ng-show="domain_access.length">
 <h4>Client headers
-    <span class="badge badge-success" ng-show="check_client_access">Accept</span>
-    <span class="badge badge-danger" ng-hide="check_client_access">Fail</span>
+    <span class="badge badge-success"
+          ng-show="check_client_access"><%=l 'Accept' %></span>
+    <span class="badge badge-danger"
+          ng-hide="check_client_access"><%=l 'Fail' %></span>
 </h4>
 <ul>
 % for my $name (sort @{$headers->names}) {

--- a/templates/main/machine_displays.html.ep
+++ b/templates/main/machine_displays.html.ep
@@ -1,5 +1,5 @@
 <div ng-show="domain.hardware.display.length<1">
-This Virtual Machine has no display hardware attached
+  <%=l 'This Virtual Machine has no display hardware attached' %>
 </div>
 
 <ul ng-show="domain_display.length>0" class="nav nav-tabs"

--- a/templates/main/manage_machine.html.ep
+++ b/templates/main/manage_machine.html.ep
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <h2>Virtual Machine <%= $domain->name %></h2>
+                        <h2><%=l 'Virtual Machine' %> <%= $domain->name %></h2>
                     </div>
                         <form action="<%= $uri %>" method="post">
                         <input type="submit" name="start" value="start" <%= $_start_disabled %>>
@@ -24,7 +24,7 @@
                         <a href="/machine/screenshot/<%= $domain->id %>.html"><%=l Screenshot %></a>
                     </form>
                     <img src="/img/screenshots/<%= $domain->id %>.png" width=400>
-                    
+
                 </div>
             </div>
         </div>

--- a/templates/main/manage_machine_edit_net.html.ep
+++ b/templates/main/manage_machine_edit_net.html.ep
@@ -16,8 +16,8 @@
                     </select>
         </li>
         <li class="list-group-item list-group-item-primary">
-            <span ng-show="item.type == 'NAT'">nat</span>
-            <span ng-show="item.type == 'bridge'">bridge</span>
+            <span ng-show="item.type == 'NAT'"><%=l 'nat' %></span>
+            <span ng-show="item.type == 'bridge'"><%=l 'bridge' %></span>
         </li>
         <li class="list-group-item">
             <select ng-model="item.network"
@@ -33,7 +33,7 @@
                         >
             </select>
             <span ng-hide="item.type == 'NAT' || network_bridges[0]">
-                No bridges found
+              <%=l 'No bridges found' %>
             </span>
         </li>
     </ul>

--- a/templates/main/manage_machine_new_disk.html.ep
+++ b/templates/main/manage_machine_new_disk.html.ep
@@ -6,8 +6,8 @@
         </div>
         <div class="col-lg-2">
             <select name="device" ng-model="add_disk.device">
-                <option>disk</option>
-                <option>cdrom</option>
+                <option><%=l 'disk' %></option>
+                <option><%=l 'cdrom' %></option>
             </select>
         </div>
     </div>
@@ -17,15 +17,21 @@
         </div>
         <div class="col-lg-2">
            <select name="type" ng-model="add_disk.type">
-                <option value='sys'>system</option>
-                <option value='swap'>tmp</option>
-                <option value='data'>data</option>
+                <option value='sys'><%=l 'system' %></option>
+                <option value='swap'><%=l 'temporary' %></option>
+                <option value='data'><%=l 'data' %></option>
             </select>
          </div>
          <div class="col-lg-6">
-            <span ng-show="add_disk.type == 'sys'">Content will be cleaned on restore</span>
-            <span ng-show="add_disk.type == 'swap'">Content will be cleaned on restore and shutdown</span>
-            <span ng-show="add_disk.type == 'data'">Content will be kept on restore</span>
+           <span ng-show="add_disk.type == 'sys'">
+             <%=l 'Content will be cleaned on restore' %>
+           </span>
+           <span ng-show="add_disk.type == 'swap'">
+             <%=l 'Content will be cleaned on restore and shutdown' %>
+           </span>
+           <span ng-show="add_disk.type == 'data'">
+             <%=l 'Content will be kept on restore' %>
+           </span>
         </div>
     </div>
     <div class="row" ng-show="add_disk.device == 'disk'">

--- a/templates/main/manage_machine_new_display.html.ep
+++ b/templates/main/manage_machine_new_display.html.ep
@@ -2,7 +2,7 @@
     <h2><%=l 'Add new Display' %></h2>
     <div class="row">
         <div class="col-lg-2">
-            <label for="type">type</label>
+            <label for="type"><%=l 'type' %></label>
         </div>
         <div class="col-lg-2">
             <select name="type" ng-model="add_display.driver"

--- a/templates/main/manage_user_groups.html.ep
+++ b/templates/main/manage_user_groups.html.ep
@@ -11,7 +11,9 @@
         >
     </select>
     <button ng-show="new_group"
-        ng-click="add_group_member(<%= $user->id %>,'<%= $user->name %>',new_group)">Add</button>
+            ng-click="add_group_member(<%= $user->id %>,'<%= $user->name %>',new_group)">
+      <%=l 'Add' %>
+    </button>
 </div>
                 {{error}}
 

--- a/templates/main/network_machines.html.ep
+++ b/templates/main/network_machines.html.ep
@@ -3,25 +3,29 @@
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">All machines</div>
+    <div class="col-md-3" align="right"><%=l 'All machines' %></div>
     <div class="col-md-1" align="left">
         <input type="checkbox" name="address" ng-model="network.all_domains"
             ng-true-value="1" ng-false-value="0"
             ng-change="check_all_domains(); update_network()"
         >
     </div>
-    <div class="col-md-8">Users from this network can run all virtual machines</div>
+    <div class="col-md-8">
+      <%=l 'Users from this network can run all virtual machines' %>
+    </div>
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">No machines</div>
+    <div class="col-md-3" align="right"><%=l 'No machines' %></div>
     <div class="col-md-1" align="left">
         <input type="checkbox" name="address" ng-model="network.no_domains"
             ng-true-value="1" ng-false-value="0"
             ng-change="check_no_domains(); update_network()"
         >
     </div>
-    <div class="col-md-8">Users from this network can run no virtual machines</div>
+    <div class="col-md-8">
+      <%=l 'Users from this network can run no virtual machines' %>
+    </div>
 </div>
 <hr/>
 
@@ -29,11 +33,10 @@
 <div ng-show="network.no_domains == 0">
 <div class="row">
     <div class="col-md-2">
-        Public
+      <%=l 'Public' %>
     </div>
-
     <div class="col-md-2">
-        Anonymous
+      <%=l 'Anonymous' %>
     </div>
 </div>
 
@@ -60,7 +63,7 @@
 
         <div ng-show="machine.anonymous == 1 && machine.allowed== 0"
             class="alert alert-warning">
-                Warning: anonymous machines won't show up unless you enable allowed.
+          Warning: anonymous machines won't show up unless you enable allowed.
         </div>
 
         <div ng-show="machine.anonymous == 1 && machine.is_public == 0"

--- a/templates/main/network_options.html.ep
+++ b/templates/main/network_options.html.ep
@@ -6,8 +6,12 @@
         <input type="text" name="name" ng-model="network.name" required
             ng-change='check_duplicate("name")'
         >
-        <span ng-show="formNetwork.name.$error.required">Network name is required</span>
-        <span ng-show="network._duplicated_name">This name is duplicated</span>
+        <span ng-show="formNetwork.name.$error.required">
+          <%=l 'Network name is required' %>
+        </span>
+        <span ng-show="network._duplicated_name">
+          <%=l 'This name is duplicated' %>
+        </span>
     </div>
 </div>
 
@@ -34,7 +38,9 @@
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">All machines</div>
+  <div class="col-md-3" align="right">
+    <%=l 'All machines' %>
+  </div>
     <div class="col-md-1" align="left">
         <input type="checkbox" name="address" ng-model="network.all_domains"
             ng-true-value="1" ng-false-value="0"

--- a/templates/main/network_remove.html.ep
+++ b/templates/main/network_remove.html.ep
@@ -1,8 +1,8 @@
 <div ng-show="network && network.id">
     Are you sure you want to remove the <%= $item %> {{network.name}}
 
-    <button ng-click="remove_network(network.id)">yes</button>
-    <button onclick="location='/admin/networks'">cancel</button>
+    <button ng-click="remove_network(network.id)"><%=l 'yes' %></button>
+    <button onclick="location='/admin/networks'"><%=l 'cancel' %></button>
 </div>
 
 <div ng-show="message">{{message}}</div>

--- a/templates/main/node_options.html.ep
+++ b/templates/main/node_options.html.ep
@@ -1,21 +1,21 @@
 <div class="container-fluid">
 <form name="formNode">
 <div class="row">
-    <div class="col-md-3" align="right">name</div>
+    <div class="col-md-3" align="right"><%=l 'name' %></div>
     <div class="col-md-8">
         <input type="text" ng-model="node.name">
     </div>
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">host</div>
+    <div class="col-md-3" align="right"><%=l 'host' %></div>
     <div class="col-md-8" align="left">
         <input type="text" ng-model="node.hostname">
     </div>
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">base storage</div>
+    <div class="col-md-3" align="right"><%=l 'base storage' %></div>
     <div class="col-md-8">
         <input type="text" ng-model="node.base_storage" ng-hide="storage_pools"
         />
@@ -27,7 +27,7 @@
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">clone storage</div>
+    <div class="col-md-3" align="right"><%=l 'clone storage' %></div>
     <div class="col-md-8">
         <input type="text" ng-model="node.clone_storage" ng-hide="storage_pools"
         />
@@ -39,7 +39,7 @@
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">default storage</div>
+    <div class="col-md-3" align="right"><%=l 'default storage' %></div>
     <div class="col-md-8">
         <input type="text" ng-model="node.default_storage" ng-hide="storage_pools"
         />
@@ -53,7 +53,7 @@
     <div class="col-md-3" align="right"></div>
     <div class="col-md-4" align="left">
         <button ng-show="node.id" class="btn btn-outline-secondary"
-            ng-click="load_node()">cancel</button>
+            ng-click="load_node()"><%=l 'cancel' %></button>
         <button class="btn btn-primary"
             ng-click="update_node()"
             ng-disabled="!formNode.$valid || formNode.$pristine

--- a/templates/main/node_remove.html.ep
+++ b/templates/main/node_remove.html.ep
@@ -24,11 +24,10 @@
             ng-click="remove_node(node.id)"
         >Yes</button>
 
-        <button onclick="location='/admin/nodes'">Cancel</button>
+        <button onclick="location='/admin/nodes'"><%=l 'Cancel' %></button>
         </div>
     </div>
 
 </div>
 
 <div ng-show="message">{{message}}</div>
-

--- a/templates/main/vm_actions.html.ep
+++ b/templates/main/vm_actions.html.ep
@@ -108,7 +108,7 @@
     <div class="col-md-7">
         <span><%=l 'Purge disk volumes' %></span>
         <div ng-hide="showmachine.has_backups">
-            This virtual machine has no backups to purge
+          <%=l 'This virtual machine has no backups to purge' %>
         </div>
     </div>
   </div>

--- a/templates/main/vm_booking_new.html.ep
+++ b/templates/main/vm_booking_new.html.ep
@@ -9,25 +9,25 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-        <label for="description">Description</label>
+        <label for="description"><%=l 'Description' %></label>
         <textarea ng-model="booking.description"></textarea>
     </div>
 </div>
 <div class="row">
-    <div class="col-md-2">Start</div>
+    <div class="col-md-2"><%=l 'Start' %></div>
     <div class="col-md-5">
         <input type="date" ng-model="booking.date_start" required/>
     </div>
 </div>
 <div class="row">
-    <div class="col-md-2">End</div>
+    <div class="col-md-2"><%=l 'End' %></div>
     <div class="col-md-5">
         <input type="date" ng-model="booking.date_end" required/>
     </div>
 </div>
 
 <div class="row">
-    <div class="col-md-2">Time</div>
+    <div class="col-md-2"><%=l 'Time' %></div>
     <div class="col-md-5">
         <input type="text" ng-model="booking.time_start" min="00:00" max="23:59"
             required
@@ -72,7 +72,7 @@ my %dow = (
         ng-model="booking.ldap_groups" required></select>
     </div>
     <div class="col-md-2">
-        <span class="badge badge-primary">add</span>
+        <span class="badge badge-primary"><%=l 'add' %></span>
     </div>
 </div>
 
@@ -81,7 +81,7 @@ my %dow = (
             <button ng-click="save_booking()"
                     ng-disabled="!form_booking.$valid || form_booking.$pristine
                         || booking.day_of_week == '0000000'">
-                    save
+              <%=l 'save' %>
             </button>
     </div>
 </div>


### PR DESCRIPTION
From https://github.com/UPC/ravada/issues/1546

    Some of the text strings in the frontend templates are hardcoded
    instead of being inside "l" code so they can be translated.