### PR TITLE
Fix/1605 dockers

### DIFF
--- a/dockerfy/dockers/back/Dockerfile
+++ b/dockerfy/dockers/back/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Backend + KVM"
 

--- a/dockerfy/dockers/front/Dockerfile
+++ b/dockerfy/dockers/front/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="ravada@telecos.upc.edu"
 LABEL description="Ravada Frontend"
 


### PR DESCRIPTION
- Fix the tzdata interactive. The environment variable must be before install.
- Upgrade Ubuntu version to 20.04 from 18.04