### PR TITLE
fix(dockers): Build local image

### DIFF
--- a/dockerfy/docker-compose.yml
+++ b/dockerfy/docker-compose.yml
@@ -24,10 +24,10 @@ services:
     networks:
       - ravada_network
     #By default download from dockerhub
-    image: ravada/front
+    #image: ravada/front
     env_file: .env
     #If you want to local build
-    #build: dockers/front/.
+    build: dockers/front/.
     restart: unless-stopped
 
     depends_on:
@@ -50,10 +50,10 @@ services:
     networks:
       - ravada_network
     #By default download from dockerhub
-    image: ravada/back
+    #image: ravada/back
     env_file: .env
     #If you want to local build
-    #build: dockers/back/.
+    build: dockers/back/.
     privileged: true
     restart: unless-stopped
 


### PR DESCRIPTION
While we find where to put the docker image and autobuilds, we let it do a docker build every time.
This solution is slow versus download an image from registry, but fixes the current situation.

issue #1611