### PR TITLE
Fix choose correct internal ip

### DIFF
--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -2410,4 +2410,19 @@ sub free_disk($self, $pool_name = undef ) {
     return $info->{available};
 }
 
+sub _is_ip_bridged($self, $ip0) {
+    my $ip = NetAddr::IP->new($ip0);
+    for my $net ( $self->vm->list_networks ) {
+        my $xml = XML::LibXML->load_xml(string
+            => $net->get_xml_description());
+        my ($xml_ip) = $xml->findnodes("/network/ip");
+        next if !$xml_ip;
+        my $address = $xml_ip->getAttribute('address');
+        my $netmask = $xml_ip->getAttribute('netmask');
+        my $net = NetAddr::IP->new($address,$netmask);
+        return 1 if $ip->within($net);
+    }
+    return 0;
+}
+
 1;

--- a/t/kvm/b10_bridged.t
+++ b/t/kvm/b10_bridged.t
@@ -1,0 +1,53 @@
+use warnings;
+use strict;
+
+use Carp qw(confess);
+use Data::Dumper;
+use IPC::Run3;
+use JSON::XS;
+use Test::More;
+
+use lib 't/lib';
+use Test::Ravada;
+
+no warnings "experimental::signatures";
+use feature qw(signatures);
+
+########################################################################
+
+sub test_bridge($vm) {
+    for my $net ( $vm->vm->list_all_networks ) {
+        my $xml = XML::LibXML->load_xml(string
+            => $net->get_xml_description());
+        my ($xml_ip) = $xml->findnodes("/network/ip");
+        my $address = $xml_ip->getAttribute('address');
+        $address =~ s/\.\d+$/.4/;
+        is($vm->_is_ip_bridged($address),1);
+    }
+    is($vm->_is_ip_bridged("127.0.0.1"),0);
+}
+
+########################################################################
+clean();
+
+for my $vm_name ( 'KVM' ) {
+
+    SKIP: {
+        my $vm = rvd_back->search_vm($vm_name);
+
+        my $msg = "SKIPPED test: No $vm_name VM found ";
+        if ($vm && $>) {
+              $msg = "SKIPPED: Test must run as root";
+              $vm = undef;
+        }
+
+        diag($msg)      if !$vm;
+        skip $msg,10    if !$vm;
+
+        test_bridge($vm);
+    }
+}
+
+end();
+
+done_testing();


### PR DESCRIPTION
When reading IP addresses from the virtual machine agent, pick the one that belongs to a bridged network.