### PR TITLE
test: pools with volatile clones

### DIFF
--- a/t/vm/p10_pools.t
+++ b/t/vm/p10_pools.t
@@ -393,7 +393,7 @@ sub test_pool_with_volatiles($vm) {
             ,remote_ip => '1.2.3.4'
         );
     }
-    wait_request(debug => 1);
+    wait_request(debug => 0);
     delete_request('start','create','clone');
     for my $clone (@clones ) {
         $clone->_data('client_status','disconnected');


### PR DESCRIPTION
Clones should be created.
As are volatile, they should be started
On shutdown, they should be destroyed
In a while, new clones should appear to honor the pool

closes #1535



