### PR TITLE
refactor: make sure second list machines is shown

### DIFF
--- a/lib/Ravada/WebSocket.pm
+++ b/lib/Ravada/WebSocket.pm
@@ -475,6 +475,9 @@ sub subscribe($self, %args) {
         $LIST_MACHINES_FIRST_TIME = 1 ;
     }
     $self->_send_answer($ws,$args{channel});
+    my $channel = $args{channel};
+    $channel =~ s{/.*}{};
+    $TIME0{$channel} = 0;
 }
 
 sub unsubscribe($self, $ws) {

--- a/lib/Ravada/WebSocket.pm
+++ b/lib/Ravada/WebSocket.pm
@@ -477,7 +477,7 @@ sub subscribe($self, %args) {
     $self->_send_answer($ws,$args{channel});
     my $channel = $args{channel};
     $channel =~ s{/.*}{};
-    $TIME0{$channel} = 0;
+    $TIME0{$channel} = 0 if $channel =~ /list_machines/i;
 }
 
 sub unsubscribe($self, $ws) {


### PR DESCRIPTION
The first time it only shows parents, so it needs to remove
the timestamp to show the clones the second time.