### PR TITLE
fix: cpu detection in bionic libvirt

### DIFF
--- a/lib/Ravada/Domain/KVM.pm
+++ b/lib/Ravada/Domain/KVM.pm
@@ -2881,6 +2881,10 @@ sub _change_hardware_cpu($self, $index, $data) {
         $vcpu->appendText($data->{vcpu}->{_text});
     }
     my ($cpu) = $doc->findnodes('/domain/cpu');
+    if (!$cpu) {
+        my ($domain) = $doc->findnodes('/domain');
+        $cpu = $domain->addNewChild(undef,'cpu');
+    }
     my $feature = delete $data->{cpu}->{feature};
 
     for my $field (keys %{$data->{cpu}}) {

--- a/lib/Ravada/Front/Domain/KVM.pm
+++ b/lib/Ravada/Front/Domain/KVM.pm
@@ -174,7 +174,7 @@ sub _sort_xml_list($list, $field) {
 }
 
 sub _xml_elements($xml, $item) {
-    confess if !defined $xml;
+    return {} if !defined $xml;
     my $text = $xml->textContent;
     $item->{_text} = $text if $text && $text !~ /\n/m;
 


### PR DESCRIPTION
Libvirt from Bionic Ubuntu 18.04 fails because the CPU definition can be empty