### PR TITLE
refactor: changes for Ubuntu Jammy 22.04

### DIFF
--- a/t/20_volumes.t
+++ b/t/20_volumes.t
@@ -379,6 +379,7 @@ sub test_qcow_format($vm) {
         next if $vol->file && $vol->file =~ /iso$/;
         my @cmd = ($QEMU_IMG,'create'
             ,'-f','qcow2'
+            ,'-F','qcow2'
             ,"-b", $vol->backing_file
             ,$vol->file
         );
@@ -386,7 +387,7 @@ sub test_qcow_format($vm) {
         my @cmd_info = ($QEMU_IMG , 'info', $vol->file);
         my ($out, $err) = $clone->_vm->run_command(@cmd_info);
         my ($bff) = $out =~ /^backing file format: (.*)/m;
-        is($bff, undef);
+        is($bff, 'qcow2');
     }
     eval { $clone->start(user_admin) };
     is(''.$@,'');

--- a/t/vm/05_open.t
+++ b/t/vm/05_open.t
@@ -7,6 +7,9 @@ use IPC::Run3;
 use JSON::XS;
 use Test::More;
 
+use feature qw(signatures);
+no warnings "experimental::signatures";
+
 use lib 't/lib';
 use Test::Ravada;
 
@@ -46,6 +49,13 @@ sub test_create_domain {
     }
 }
 
+sub test_which($vm) {
+    my $ls = $vm->_which("ls");
+    ok($ls);
+}
+
+###############################################################
+
 clean();
 my $id = 10;
 
@@ -75,6 +85,7 @@ for my $vm_type( vm_names() ) {
 
     if (!$< || $vm_type ne 'KVM') {
         init_vm($vm);
+        test_which($vm);
         test_create_domain($vm, $vm_type) if rvd_back->search_vm($vm_type);
     }
 


### PR DESCRIPTION
- default backing format is now qcow2
- search for which in /bin and /usr/bin