### PR TITLE
Remove hardcoded strings, add to localisation file

### DIFF
--- a/lib/Ravada/I18N/en.po
+++ b/lib/Ravada/I18N/en.po
@@ -218,8 +218,8 @@ msgstr "messages"
 msgid "Admin tools"
 msgstr "Admin tools"
 
-msgid "Remove base"
-msgstr "Remove base"
+msgid "Remove Base"
+msgstr "Remove Base"
 
 msgid "Restore"
 msgstr "Restore"
@@ -282,15 +282,14 @@ msgstr ""
 "Be aware that in Windows, Spice redirection is not automatic. It is "
 "necessary to associate protocol"
 
-msgid "To make this possible, download"
-msgstr "To make this possible, download"
+msgid "To make this possible, copy the content of"
+msgstr "To make this possible, copy the content of"
 
-msgid ""
-"or copy the following lines in an ASCII file and save with extension .reg, "
-"then execute the file."
-msgstr ""
-"or copy the following lines in an ASCII file and save with extension .reg, "
-"then execute the file."
+msgid "to an ASCII file and save it with a .reg extension, then execute the file."
+msgstr "to an ASCII file and save it with a .reg extension, then execute the file."
+
+msgid "Please, make sure you have the right path and release, according to your PC configuration."
+msgstr "Please, make sure you have the right path and release, according to your PC configuration."
 
 msgid "Login"
 msgstr "Login"
@@ -328,11 +327,11 @@ msgstr "Permissions"
 msgid "can change the settings of owned virtual machines."
 msgstr "can change the settings of owned virtual machines."
 
-msgid "can change the settings of any virtual machines."
-msgstr "can change the settings of any virtual machines."
+msgid "can change the settings of any virtual machine."
+msgstr "can change the settings of any virtual machine."
 
-msgid "can change the settings of any virtual machines "
-msgstr "can change the settings of any virtual machines"
+msgid "can change the settings of any virtual machine "
+msgstr "can change the settings of any virtual machine "
 
 msgid "cloned from one base owned by the user."
 msgstr "cloned from one base owned by the user."
@@ -361,8 +360,8 @@ msgstr "can hibernate clones from virtual machines owned by the user."
 msgid "can hibernate any clone."
 msgstr "can hibernate any clone."
 
-msgid "can remove any virtual machines owned by the user."
-msgstr "can remove any virtual machines owned by the user."
+msgid "can remove any virtual machine owned by the user."
+msgstr "can remove any virtual machine owned by the user."
 
 msgid "can remove any virtual machine."
 msgstr "can remove any virtual machine."
@@ -435,8 +434,8 @@ msgstr "Backend selection is required."
 msgid "ISO image selection is required."
 msgstr "ISO image selection is required."
 
-msgid "Template selection is required."
-msgstr "Template selection is required."
+msgid "Template selection is required"
+msgstr "Template selection is required"
 
 msgid "A machine with that name already exists."
 msgstr "A machine with that name already exists."
@@ -459,11 +458,11 @@ msgstr ""
 msgid "monitoring"
 msgstr "monitoring"
 
-msgid "Are you sure you want to remove the Base of"
-msgstr "Are you sure you want to remove the Base of"
+msgid "Are you sure you want to remove the base of"
+msgstr "Are you sure you want to remove the base of"
 
-msgid "Are you sure you want to prepare the Base of"
-msgstr "Are you sure you want to prepare the Base of"
+msgid "Are you sure you want to prepare the base of"
+msgstr "Are you sure you want to prepare the base of"
 
 msgid "Are you sure you want to change the Public state of"
 msgstr "Are you sure you want to change the Public state of"
@@ -708,17 +707,17 @@ msgstr "Password must be at least 5 characters"
 msgid "Password can only contain words and numbers"
 msgstr "Password can only contain words and numbers"
 
-msgid "Confirm Password is required"
-msgstr "Confirm Password is required"
+msgid "Confirm password is required"
+msgstr "Confirm password is required"
 
-msgid "Confirm Password can not exceed 20 characters"
-msgstr "Confirm Password can not exceed 20 characters"
+msgid "Confirm password can not exceed 20 characters"
+msgstr "Confirm password can not exceed 20 characters"
 
-msgid "Confirm Password must be at least 5 characters"
-msgstr "Confirm Password must be at least 5 characters"
+msgid "Confirm password must be at least 5 characters"
+msgstr "Confirm password must be at least 5 characters"
 
-msgid "Confirm Password can only contain words and numbers"
-msgstr "Confirm Password can only contain words and numbers"
+msgid "Confirm password can only contain words and numbers"
+msgstr "Confirm password can only contain words and numbers"
 
 msgid "This information will be available to the users"
 msgstr "This information will be available to the users"
@@ -732,8 +731,8 @@ msgstr "Owner"
 msgid "Change the owner of the machine"
 msgstr "Change the owner of the machine"
 
-msgid "Press SHIFT + F12 to exit"
-msgstr "Press SHIFT + F12 to exit"
+msgid "Press SHIFT + F12 to exit the virtual machine"
+msgstr "Press SHIFT + F12 to exit the virtual machine"
 
 msgid "If you can not see the machine screen in a few seconds check for a file called"
 msgstr ""
@@ -794,8 +793,8 @@ msgstr "Add"
 msgid "The changes will apply on next restart"
 msgstr "The changes will apply on next restart"
 
-msgid "This VM is running and can't be renamed."
-msgstr "This VM is running and can't be renamed."
+msgid "This machine is running and can't be renamed."
+msgstr "This machine is running and can't be renamed."
 
 msgid "Thanks to:"
 msgstr "Thanks to:"
@@ -1057,3 +1056,995 @@ msgstr "There are no active virtual machines"
 
 msgid "reload list"
 msgstr "reload list"
+
+msgid "Group"
+msgstr "Group"
+
+msgid "New group member"
+msgstr "New group member"
+
+msgid "This group has been removed."
+msgstr "This group has been removed."
+
+msgid "Remove group"
+msgstr "Remove group"
+
+msgid "Are you sure you want to remove this group ?"
+msgstr "Are you sure you want to remove this group ?"
+
+msgid "object class:"
+msgstr "object class:"
+
+msgid "dn:"
+msgstr "dn:"
+
+msgid "Groups require a LDAP server configured."
+msgstr "Groups require a LDAP server configured."
+
+msgid "See documentation about:"
+msgstr "See documentation about:"
+
+msgid "Configure LDAP Authentication"
+msgstr "Configure LDAP Authentication"
+
+msgid "Setup a LDAP Server"
+msgstr "Setup a LDAP Server"
+
+msgid "Groups"
+msgstr "Groups"
+
+msgid "New Group"
+msgstr "New Group"
+
+msgid "Loading ..."
+msgstr "Loading ..."
+
+msgid "Show/Hide clones"
+msgstr "Show/Hide clones"
+
+msgid "Public"
+msgstr "Public"
+
+msgid "Autostart"
+msgstr "Autostart"
+
+msgid "Node"
+msgstr "Node"
+
+msgid "Manage machine"
+msgstr "Manage machine"
+
+msgid "Volatile"
+msgstr "Volatile"
+
+msgid "Hibernated"
+msgstr "Hibernated"
+
+msgid "ShutDown"
+msgstr "ShutDown"
+
+msgid "No message to show!"
+msgstr "No message to show!"
+
+msgid "Networks"
+msgstr "Networks"
+
+msgid "New Network"
+msgstr "New Network"
+
+msgid "requires password"
+msgstr "requires password"
+
+msgid "Nodes"
+msgstr "Nodes"
+
+msgid "Type"
+msgstr "Type"
+
+msgid "Bases"
+msgstr "Bases"
+
+msgid "Action"
+msgstr "Action"
+
+msgid "Active"
+msgstr "Active"
+
+msgid "Disabled"
+msgstr "Disabled"
+
+msgid "This node is local"
+msgstr "This node is local"
+
+msgid "Refresh"
+msgstr "Refresh"
+
+msgid "Enable"
+msgstr "Enable"
+
+msgid "Disable"
+msgstr "Disable"
+
+msgid "Confirm disable node"
+msgstr "Confirm disable node"
+
+msgid "Disabling this node will shut all the"
+msgstr "Disabling this node will shut all the"
+
+msgid "machines down."
+msgstr "machines down."
+
+msgid "Global Settings"
+msgstr "Global Settings"
+
+msgid "Frontend"
+msgstr "Frontend"
+
+msgid "Fallback"
+msgstr "Fallback"
+
+msgid "Maintenance"
+msgstr "Maintenance"
+
+msgid "Admin users can still log in from"
+msgstr "Admin users can still log in from"
+
+msgid "Maintenance Start"
+msgstr "Maintenance Start"
+
+msgid "Maintenance End"
+msgstr "Maintenance End"
+
+msgid "Debug"
+msgstr "Debug"
+
+msgid "Debug Ports"
+msgstr "Debug Ports"
+
+msgid "Debug Ports Exposed"
+msgstr "Debug Ports Exposed"
+
+msgid "Display Password"
+msgstr "Display Password"
+
+msgid "Enables display password when available"
+msgstr "Enables display password when available"
+
+msgid "Bookings"
+msgstr "Bookings"
+
+msgid "Bookings require LDAP authentication."
+msgstr "Bookings require LDAP authentication."
+
+msgid "Start Limit"
+msgstr "Start Limit"
+
+msgid "Number of virtual machines that normal users can have running at the same time"
+msgstr "Number of virtual machines that normal users can have running at the same time"
+
+msgid "Port expose"
+msgstr "Port expose"
+
+msgid "Minimum port number to expose virtual machine services."
+msgstr "Minimum port number to expose virtual machine services."
+
+msgid "cancel"
+msgstr "cancel"
+
+msgid "New user"
+msgstr "New user"
+
+msgid "Error:"
+msgstr "Error:"
+
+msgid "Web Service connection failed."
+msgstr "Web Service connection failed."
+
+msgid "Check"
+msgstr "Check"
+
+msgid "Ravada Apache documentation"
+msgstr "Ravada Apache documentation"
+
+
+msgid "Client"
+msgstr "Client"
+
+msgid "LDAP"
+msgstr "LDAP"
+
+msgid "Display URL :"
+msgstr "Display URL :"
+
+
+msgid "Display IP :"
+msgstr "Display IP :"
+
+msgid "Display Port :"
+msgstr "Display Port :"
+
+msgid "Display Port secure :"
+msgstr "Display Port secure :"
+
+msgid "Sorry"
+msgstr "Sorry"
+
+msgid "Server in maintenance until"
+msgstr "Server in maintenance until"
+
+msgid "vCPU allocation"
+msgstr "vCPU allocation"
+
+msgid "mode"
+msgstr "mode"
+
+msgid "check"
+msgstr "check"
+
+msgid "match"
+msgstr "match"
+
+msgid "model"
+msgstr "model"
+
+msgid "fallback"
+msgstr "fallback"
+
+msgid "CPU Features"
+msgstr "CPU Features"
+
+msgid "New feature"
+msgstr "New feature"
+
+msgid "add"
+msgstr "add"
+
+msgid "bus"
+msgstr "bus"
+
+msgid "capacity"
+msgstr "capacity"
+
+msgid "ISO file"
+msgstr "ISO file"
+
+msgid "boot order"
+msgstr "boot order"
+
+msgid "state"
+msgstr "state"
+
+msgid "on"
+msgstr "on"
+
+msgid "off"
+msgstr "off"
+
+msgid "hidden"
+msgstr "hidden"
+
+msgid "nat"
+msgstr "nat"
+
+msgid "bridge"
+msgstr "bridge"
+
+msgid "primary"
+msgstr "primary"
+
+msgid "Primary video devices will move to first"
+msgstr "Primary video devices will move to first"
+
+msgid "Primary can not be unset, enable it in another video device"
+msgstr "Primary can not be unset, enable it in another video device"
+
+msgid "ram"
+msgstr "ram"
+
+msgid "vram"
+msgstr "vram"
+
+msgid "heads"
+msgstr "heads"
+
+msgid "Set defaults"
+msgstr "Set defaults"
+
+msgid "Add new disk"
+msgstr "Add new disk"
+
+msgid "device"
+msgstr "device"
+
+msgid "sys"
+msgstr "sys"
+
+msgid "swap"
+msgstr "swap"
+
+msgid "size"
+msgstr "size"
+
+msgid "allocation"
+msgstr "allocation"
+
+msgid "Add new Display"
+msgstr "Add new Display"
+
+msgid "PrepareBase"
+msgstr "PrepareBase"
+
+msgid "Add to group"
+msgstr "Add to group"
+
+msgid "No LDAP groups created."
+msgstr "No LDAP groups created."
+
+msgid "Add groups"
+msgstr "Add groups"
+
+msgid "User is not member of any group."
+msgstr "User is not member of any group."
+
+msgid "New password"
+msgstr "New password"
+
+msgid "Force change password on first access"
+msgstr "Force change password on first access"
+
+msgid "Oops!"
+msgstr "Oops!"
+
+msgid "New Password must be at least 6 characters"
+msgstr "New Password must be at least 6 characters"
+
+msgid "Set New Password"
+msgstr "Set New Password"
+
+msgid "This user has never logged in the Ravada server."
+msgstr "This user has never logged in the Ravada server."
+
+msgid "Import"
+msgstr "Import"
+
+msgid "Error: the LDAP entry for this user has been removed."
+msgstr "Error: the LDAP entry for this user has been removed."
+
+msgid "No machines found"
+msgstr "No machines found"
+
+msgid "Warning: anonymous machines won't show up unless you set them public."
+msgstr "Warning: anonymous machines won't show up unless you set them public."
+
+msgid "New network"
+msgstr "New network"
+
+msgid "name"
+msgstr "name"
+
+msgid "address"
+msgstr "address"
+
+msgid "Network address is required."
+msgstr "Network address is required."
+
+msgid "Invalid IP network address. Expecting a.b.c.d/e"
+msgstr "Invalid IP network address. Expecting a.b.c.d/e"
+
+msgid "This address is duplicated"
+msgstr "This address is duplicated"
+
+msgid "password"
+msgstr "password"
+
+msgid "Requires viewer password when implemented"
+msgstr "Requires viewer password when implemented"
+
+msgid "Set either"
+msgstr "Set either"
+
+msgid "all machines"
+msgstr "all machines"
+
+msgid "or"
+msgstr "or"
+
+msgid "no machines"
+msgstr "no machines"
+
+msgid "for users in this network"
+msgstr "for users in this network"
+
+msgid "Network"
+msgstr "Network"
+
+msgid "saved."
+msgstr "saved."
+
+msgid "Are you sure you want to remove the"
+msgstr "Are you sure you want to remove the"
+
+msgid "yes"
+msgstr "yes"
+
+msgid "Choose the virtualization type of the Node."
+msgstr "Choose the virtualization type of the Node."
+
+msgid "Check connection to"
+msgstr "Check connection to"
+
+msgid "A node with that address already exists."
+msgstr "A node with that address already exists."
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Testing connection to"
+msgstr "Testing connection to"
+
+msgid "No bases found"
+msgstr "No bases found"
+
+msgid "This base has"
+msgstr "This base has"
+
+msgid "backup directory"
+msgstr "backup directory"
+
+msgid "This is a main node and can't be removed."
+msgstr "This is a main node and can't be removed."
+
+msgid "Are you sure you want to remove the node"
+msgstr "Are you sure you want to remove the node"
+
+msgid "This node has"
+msgstr "This node has"
+
+msgid "bases."
+msgstr "bases."
+
+msgid "Remove bases in node"
+msgstr "Remove bases in node"
+
+msgid "Request"
+msgstr "Request"
+
+msgid "Removing Virtual Machine"
+msgstr "Removing Virtual Machine"
+
+msgid "This can't be undone"
+msgstr "This can't be undone"
+
+msgid "and will remove all the disk and information of this virtual machine."
+msgstr "and will remove all the disk and information of this virtual machine."
+
+msgid "Please insert"
+msgstr "Please insert"
+
+msgid "not"
+msgstr "not"
+
+msgid "to apply."
+msgstr "to apply."
+
+msgid "Display"
+msgstr "Display"
+
+msgid "Machine Information"
+msgstr "Machine Information"
+
+msgid "Internal IP"
+msgstr "Internal IP"
+
+msgid "waiting for network to come up"
+msgstr "waiting for network to come up"
+
+msgid "Max Memory"
+msgstr "Max Memory"
+
+msgid "CPUs"
+msgstr "CPUs"
+
+msgid "reopen"
+msgstr "reopen"
+
+msgid "down"
+msgstr "down"
+
+msgid "I don't know settings tabs for:"
+msgstr "I don't know settings tabs for:"
+
+msgid "Hardware"
+msgstr "Hardware"
+
+msgid "Base"
+msgstr "Base"
+
+msgid "Ports"
+msgstr "Ports"
+
+msgid "Access"
+msgstr "Access"
+
+msgid "Waiting for requests to complete"
+msgstr "Waiting for requests to complete"
+
+msgid "Recent requests"
+msgstr "Recent requests"
+
+msgid "Force ShutDown"
+msgstr "Force ShutDown"
+
+msgid "Reboot"
+msgstr "Reboot"
+
+msgid "Force Reboot"
+msgstr "Force Reboot"
+
+msgid "Compact"
+msgstr "Compact"
+
+msgid "Compact disk volumes"
+msgstr "Compact disk volumes"
+
+msgid "This virtual machine has already been compacted"
+msgstr "This virtual machine has already been compacted"
+
+msgid "Purge"
+msgstr "Purge"
+
+msgid "Purge disk volumes"
+msgstr "Purge disk volumes"
+
+msgid "This machine is locked by process"
+msgstr "This machine is locked by process"
+
+msgid "process"
+msgstr "process"
+
+msgid "This base can't be removed because the domain has clones."
+msgstr "This base can't be removed because the domain has clones."
+
+msgid "Loading machine"
+msgstr "Loading machine"
+
+msgid "waiting for requests"
+msgstr "waiting for requests"
+
+msgid "Loading nodes"
+msgstr "Loading nodes"
+
+msgid "Node down"
+msgstr "Node down"
+
+msgid "Node disabled"
+msgstr "Node disabled"
+
+msgid "This base has clones"
+msgstr "This base has clones"
+
+msgid "today"
+msgstr "today"
+
+msgid "New Booking"
+msgstr "New Booking"
+
+msgid "Exec. time"
+msgstr "Exec. time"
+
+msgid "Exec clones sequentially"
+msgstr "Exec clones sequentially"
+
+msgid "RAM (Gb)"
+msgstr "RAM (Gb)"
+
+msgid "This name is invalid. It can only contain alphabetic, numbers, undercores and dashes and must start by a letter."
+msgstr "This name is invalid. It can only contain alphabetic, numbers, undercores and dashes and must start by a letter."
+
+msgid "I can't find"
+msgstr "I can't find"
+
+msgid "driver"
+msgstr "driver"
+
+msgid "This machine is running and can't be modified."
+msgstr "This machine is running and can't be modified."
+
+msgid "This machine is base and can't be modified."
+msgstr "This machine is base and can't be modified."
+
+msgid "Danger: This will destroy all the disk data permantently."
+msgstr "Danger: This will destroy all the disk data permantently."
+
+msgid "Type the name of the volume disk to confirm:"
+msgstr "Type the name of the volume disk to confirm:"
+
+msgid "No hardware found for"
+msgstr "No hardware found for"
+
+msgid "-- choose hardware --"
+msgstr "-- choose hardware --"
+
+msgid "This machine is base and it can't be modified."
+msgstr "This machine is base and it can't be modified."
+
+msgid "The VM is"
+msgstr "The VM is"
+
+msgid "stopped"
+msgstr "stopped"
+
+msgid "Nothing to monitoring"
+msgstr "Nothing to monitoring"
+
+msgid "Start after migration"
+msgstr "Start after migration"
+
+msgid "This virtual machine is running. It must be shut down before migrate."
+msgstr "This virtual machine is running. It must be shut down before migrate."
+
+msgid "Are you sure you want to migrate"
+msgstr "Are you sure you want to migrate"
+
+msgid "Max memory (MB)"
+msgstr "Max memory (MB)"
+
+msgid "Current memory (MB)"
+msgstr "Current memory (MB)"
+
+msgid "Run Timeout"
+msgstr "Run Timeout"
+
+msgid "Shutdown Timeout"
+msgstr "Shutdown Timeout"
+
+msgid "The machine will power off after this minutes after shutdown."
+msgstr "The machine will power off after this minutes after shutdown."
+
+msgid "Clones created from this machine will be removed on shutdown."
+msgstr "Clones created from this machine will be removed on shutdown."
+
+msgid "Virtual Machine will start on host start."
+msgstr "Virtual Machine will start on host start."
+
+msgid "Shutdown disconnected"
+msgstr "Shutdown disconnected"
+
+msgid "Virtual Machine will be shutdown when user disconnects."
+msgstr "Virtual Machine will be shutdown when user disconnects."
+
+msgid "Clones are volatile, so all the pool will be started."
+msgstr "Clones are volatile, so all the pool will be started."
+
+msgid "Error: you want to have"
+msgstr "Error: you want to have"
+
+msgid "but there are only"
+msgstr "but there are only"
+
+msgid "clones defined."
+msgstr "clones defined."
+
+msgid "Port"
+msgstr "Port"
+
+msgid "Restricted"
+msgstr "Restricted"
+
+msgid "Public Port"
+msgstr "Public Port"
+
+msgid "Only remote client can access this port if restricted"
+msgstr "Only remote client can access this port if restricted"
+
+msgid "Only remote client can access this port"
+msgstr "Only remote client can access this port"
+
+msgid "Any remote client can access this port"
+msgstr "Any remote client can access this port"
+
+msgid "Refresh ports"
+msgstr "Refresh ports"
+
+msgid "Prepare Base"
+msgstr "Prepare Base"
+
+msgid "Change"
+msgstr "Change"
+
+msgid "Rebase all the clones to a new base"
+msgstr "Rebase all the clones to a new base"
+
+msgid "Rebase this machine to another virtual machine"
+msgstr "Rebase this machine to another virtual machine"
+
+msgid "Warning"
+msgstr "Warning"
+
+msgid "Changing the base of a virtual machine is potentially dangerous and can't be undone."
+msgstr "Changing the base of a virtual machine is potentially dangerous and can't be undone."
+
+msgid "No, cancel"
+msgstr "No, cancel"
+
+msgid "Yes, rebase"
+msgstr "Yes, rebase"
+
+msgid "Rebase"
+msgstr "Rebase"
+
+msgid "Remove the base prepared from this machine"
+msgstr "Remove the base prepared from this machine"
+
+msgid "Remove Clones"
+msgstr "Remove Clones"
+
+msgid "This virtual machine has clones that are bases and won't be removed"
+msgstr "This virtual machine has clones that are bases and won't be removed"
+
+msgid "This machine is hibernated and can't be renamed."
+msgstr "This machine is hibernated and can't be renamed."
+
+msgid "New name"
+msgstr "New name"
+
+msgid "Spinoff clone"
+msgstr "Spinoff clone"
+
+msgid "Spinoff this clone from its base."
+msgstr "Spinoff this clone from its base."
+
+msgid "Are you sure you want to spinoff from the base ?"
+msgstr "Are you sure you want to spinoff from the base ?"
+
+msgid "Enter Old Password"
+msgstr "Enter Old Password"
+
+msgid "Enter New Password"
+msgstr "Enter New Password"
+
+msgid "Re-Enter New Password"
+msgstr "Re-Enter New Password"
+
+msgid "Old Password is required"
+msgstr "Old Password is required"
+
+msgid "Old Password can only contain words and numbers"
+msgstr "Old Password can only contain words and numbers"
+
+msgid "New Password is required"
+msgstr "New Password is required"
+
+msgid "New Password can only contain words and numbers"
+msgstr "New Password can only contain words and numbers"
+
+msgid "Old and New Passwords match!"
+msgstr "Old and New Passwords match!"
+
+msgid "Repeated New Password is required"
+msgstr "Repeated New Password is required"
+
+msgid "Password and their confirmation do not match!"
+msgstr "Password and their confirmation do not match!"
+
+msgid "Today Schedule"
+msgstr "Today Schedule"
+
+msgid "This server has reservations for today. Machines from users out of the booking list will be shutdown."
+msgstr "This server has reservations for today. Machines from users out of the booking list will be shutdown."
+
+msgid "allowed"
+msgstr "allowed"
+
+msgid "not allowed"
+msgstr "not allowed"
+
+msgid "Machines Notifications"
+msgstr "Machines Notifications"
+
+msgid "Machine"
+msgstr "Machine"
+
+msgid "Group name"
+msgstr "Group name"
+
+msgid "Enter group name"
+msgstr "Enter group name"
+
+msgid "Group name is required"
+msgstr "Group name is required"
+
+msgid "Group name can not exceed 80 characters"
+msgstr "Group name can not exceed 80 characters"
+
+msgid "added"
+msgstr "added"
+
+msgid "The source machine is not a base. It must be prepared before it can be copied. This process may take some minutes."
+msgstr "The source machine is not a base. It must be prepared before it can be copied. This process may take some minutes."
+
+msgid "Choose the virtualization type of the Virtual Machine."
+msgstr "Choose the virtualization type of the Virtual Machine."
+
+msgid "Type the template name"
+msgstr "Type the template name"
+
+msgid "Select the .iso file the machine will utilize when installing the OS."
+msgstr "Select the .iso file the machine will utilize when installing the OS."
+
+msgid "Type the ISO pathname"
+msgstr "Type the ISO pathname"
+
+msgid "This ISO is being downloaded. The virtual machine will be created after."
+msgstr "This ISO is being downloaded. The virtual machine will be created after."
+
+msgid "System Disk: (GB)"
+msgstr "System Disk: (GB)"
+
+msgid "The Minimum Disk Size needed for this ISO is"
+msgstr "The Minimum Disk Size needed for this ISO is"
+
+msgid "Advanced options"
+msgstr "Advanced options"
+
+msgid "Swap"
+msgstr "Swap"
+
+msgid "disabled"
+msgstr "disabled"
+
+msgid "The Minimum Swap Disk Size needed for this ISO is"
+msgstr "The Minimum Swap Disk Size needed for this ISO is"
+
+msgid "Data"
+msgstr "Data"
+
+msgid "BIOS"
+msgstr "BIOS"
+
+msgid "Legacy"
+msgstr "Legacy"
+
+msgid "UEFI"
+msgstr "UEFI"
+
+msgid "Start after create the virtual machine"
+msgstr "Start after create the virtual machine"
+
+msgid "Invalid Template"
+msgstr "Invalid Template"
+
+msgid "Please select an ISO file"
+msgstr "Please select an ISO file"
+
+msgid "Passwords do not match!"
+msgstr "Passwords do not match!"
+
+msgid "Support Contact"
+msgstr "Support Contact"
+
+msgid "If you have any issue, you can contact the Suport crew and we will try to help you. Please, only contact Support Center if it is strictly necessary."
+msgstr "If you have any issue, you can contact the Suport crew and we will try to help you. Please, only contact Support Center if it is strictly necessary."
+
+msgid "Email"
+msgstr "Email"
+
+msgid "Phone Number"
+msgstr "Phone Number"
+
+msgid "Attachment"
+msgstr "Attachment"
+
+msgid "Contact Method"
+msgstr "Contact Method"
+
+msgid "Phone"
+msgstr "Phone"
+
+msgid "Fill required camps with valid data"
+msgstr "Fill required camps with valid data"
+
+msgid "Will be destroyed on shutdown"
+msgstr "Will be destroyed on shutdown"
+
+msgid "volatile"
+msgstr "volatile"
+
+msgid "hide"
+msgstr "hide"
+
+msgid "Hide active"
+msgstr "Hide active"
+
+msgid "filter"
+msgstr "filter"
+
+msgid "Reload"
+msgstr "Reload"
+
+msgid "Congrats"
+msgstr "Congrats"
+
+msgid "The new user"
+msgstr "The new user"
+
+msgid "has been added successfully!"
+msgstr "has been added successfully!"
+
+msgid "What do you want to do now?"
+msgstr "What do you want to do now?"
+
+msgid "Add another user"
+msgstr "Add another user"
+
+msgid "Create a new group"
+msgstr "Create a new group"
+
+msgid "Schedule"
+msgstr "Schedule"
+
+msgid "groups"
+msgstr "groups"
+
+msgid "nodes"
+msgstr "nodes"
+
+msgid "networks"
+msgstr "networks"
+
+msgid "settings"
+msgstr "settings"
+
+msgid "can manage users."
+msgstr "can manage users."
+
+msgid "Can expose virtual machine ports."
+msgstr "Can expose virtual machine ports."
+
+msgid "Can rename any virtual machine owned by the user."
+msgstr "Can rename any virtual machine owned by the user."
+
+msgid "Can rename any virtual machine."
+msgstr "Can rename any virtual machine."
+
+msgid "Can rename clones from virtual machines owned by the user."
+msgstr "Can rename clones from virtual machines owned by the user."
+
+msgid "Can shutdown own virtual machines."
+msgstr "Can shutdown own virtual machines."
+
+msgid "Can reboot own virtual machines."
+msgstr "Can reboot own virtual machines."
+
+msgid "Can reboot all virtual machines."
+msgstr "Can reboot all virtual machines."
+
+msgid "Can reboot clones own virtual machines."
+msgstr "Can reboot clones own virtual machines."
+
+msgid "Can get a screenshot of own virtual machines."
+msgstr "Can get a screenshot of own virtual machines."
+
+msgid "Can have an unlimited amount of machines started."
+msgstr "Can have an unlimited amount of machines started."
+
+msgid "Can view groups."
+msgstr "Can view groups."
+
+msgid "Can manage groups."
+msgstr "Can manage groups."
+
+msgid "can have their own limit on started machines."
+msgstr "can have their own limit on started machines."
+
+msgid "Search group"
+msgstr "Search group"
+
+msgid "No Results Found"
+msgstr "No Results Found"
+
+msgid "Client headers"
+msgstr "Client headers"
+
+msgid "locked"
+msgstr "locked"

--- a/public/js/booking/ldapGroup.component.html
+++ b/public/js/booking/ldapGroup.component.html
@@ -1,6 +1,6 @@
 <div>
 
-    <input type="text" ng-model="$ctrl.group_selected" placeholder="Search group"
+    <input type="text" ng-model="$ctrl.group_selected" placeholder="<%=l 'Search group' %>"
            ng-if="$ctrl.editable"
            ng-required="!$ctrl.ngModel.$valid"
            uib-typeahead="name for name in $ctrl.getGroups($viewValue)"
@@ -11,7 +11,7 @@
            class="form-control">
     <i ng-show="$ctrl.loadingGroups" class="fas fa-refresh"></i>
     <div ng-show="$ctrl.noResults">
-        <i class="fas fa-times"></i> No Results Found
+        <i class="fas fa-times"></i> <%=l 'No Results Found' %>
     </div>
 
     <div class="container-fluid">

--- a/templates/bootstrap/new_user_ok.html.ep
+++ b/templates/bootstrap/new_user_ok.html.ep
@@ -8,16 +8,16 @@
            <div class="page-header">
                 <div class="card">
                     <div class="card-header">
-                        <h2>Congrats
+                        <h2><%=l 'Congrats' %>
                             <!--<button style="float: right; margin: 0 10px;" onclick="location='/users'" ><i class="fa fa-arrow-circle-left" aria-hidden="true"></i></button>-->
                         </h2>
                     </div>
                     <div class="card-text alert alert-success">
-                        The new user <strong><%= $username %> </strong> has been added successfully!
+                        <%=l 'The new user' %> <strong><%= $username %> </strong> <%=l 'has been added successfully!' %>
                     </div>
                    <div class="card-body">
-                        <h4>What do you want to do now?</h4>
-                        <button class="btn btn-success" style="float: center; " onclick="location='/users/register'" ><i class="fas fa-plus-circle fa-2x" aria-hidden="true"></i>Add another user</button>
+                        <h4><%=l 'What do you want to do now?' %></h4>
+                        <button class="btn btn-success" style="float: center; " onclick="location='/users/register'" ><i class="fas fa-plus-circle fa-2x" aria-hidden="true"></i><%=l 'Add another user' %></button>
                     </div>
                       
                 </div>

--- a/templates/bootstrap/requests.html.ep
+++ b/templates/bootstrap/requests.html.ep
@@ -21,7 +21,7 @@
         ng-click="show_requests = !show_requests"
     ><%=l 'Requests' %>
         <span class="badge badge-warning" ng-hide="show_requests">{{requests.length}}</span>
-        <span class="badge badge-warning" ng-show="show_requests">hide</span>
+        <span class="badge badge-warning" ng-show="show_requests"><%=l 'hide' %></span>
     </button>
     <button type="button" class="btn btn-outline-primary btn-sm"
         ng-disabled="!n_active || (!n_active_hidden && !show_active)"
@@ -39,9 +39,9 @@
 
     <button type="button" class="btn btn-outline-primary btn-sm">
         <a ng-show="hide_clones" ng-click="showClones(true)"
-            align="right"><%=l 'show clones' %></a>
+            align="right"><%=l 'Show clones' %></a>
         <a ng-show="!hide_clones" ng-click="showClones(false)"
-            align="right"><%=l 'hide clones' %></a>
+            align="right"><%=l 'Hide clones' %></a>
     </button>
 
     <input type="text" ng-model="filter" placeholder="<%=l 'filter' %>"

--- a/templates/main/admin_group.html.ep
+++ b/templates/main/admin_group.html.ep
@@ -12,9 +12,9 @@
               <div class="card" id="admin-content">
                 <div class="card-header">
                     <h2 class="display-5"><%=l 'Group' %> <%= $name %></h2>
-                    object class: <b><%= join(" - ",sort @$object_class) %></b>
+                    <%=l 'object class:' %> <b><%= join(" - ",sort @$object_class) %></b>
                     <br/>
-                    dn: <b><%= $group->dn %></b>
+                    <%=l 'dn:' %> <b><%= $group->dn %></b>
                 </div>
               </div>
             </div>
@@ -69,13 +69,13 @@
                                      ng-show="group_members && group_members.length==0
                                                && !removed && !confirm_remove"
                                      ng-click="confirm_remove=true"
-                                     value="Remove group"/>
+                                     value="<%=l 'Remove group' %>"/>
                 <div ng-show="confirm_remove" class="card">
                 <div ng-show="confirm_remove" class="card-body">
                     <span><%=l 'Are you sure you want to remove this group ?'%></span><br/>
-                    <input type="button" class="btn btn-primary" value="Yes"
+                    <input type="button" class="btn btn-primary" value="<%=l 'Yes' %>"
                     ng-click="remove_group()"/>
-                    <input type="button" class="btn btn-danger" value="No"
+                    <input type="button" class="btn btn-danger" value="<%=l 'No' %>"
                     ng-click="confirm_remove=false"/>
 
                 </div>

--- a/templates/main/admin_groups.html.ep
+++ b/templates/main/admin_groups.html.ep
@@ -13,12 +13,12 @@
                   <div class="card-header" ng-show="!<%= $FEATURE->{ldap} %>">
                     <h2 class="display-5"><%=l 'Groups' %></h2>
                     <p>
-                      Groups require a LDAP server configured.
-                      See documentation about:
+                      <%=l 'Groups require a LDAP server configured.' %>
+                      <%=l 'See documentation about:' %>
                     </p>
                     <ul>
-                        <li><a href="https://ravada.readthedocs.io/en/latest/docs/auth_ldap.html">Configure LDAP Authentication</a></li>
-                        <li><a href="https://ravada.readthedocs.io/en/latest/docs/ldap_local.html">Setup a LDAP Server</a></li>
+                        <li><a href="https://ravada.readthedocs.io/en/latest/docs/auth_ldap.html"><%=l 'Configure LDAP Authentication' %></a></li>
+                        <li><a href="https://ravada.readthedocs.io/en/latest/docs/ldap_local.html"><%=l 'Setup a LDAP Server' %></a></li>
                     </ul>
                   </div>
 

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -12,7 +12,7 @@
 <div class="panel-body">
     <div class="col-lg-12">
       <div ng-show="pingbe_fail" class="alert alert-danger" ng-cloak>
-        <strong><%=l 'Error!' %></strong><%=l 'Backend no available!' %>
+        <strong><%=l 'Error!' %></strong><%=l 'Backend not available!' %>
       </div>
 %       if ($USER->is_operator || $USER->is_admin) {
             %= include 'main/check_ws'

--- a/templates/main/admin_messages.html.ep
+++ b/templates/main/admin_messages.html.ep
@@ -11,7 +11,7 @@
 <div class="panel-body">
     <div class="col-lg-12">
         <div ng-show="pingbe_fail" class="alert alert-danger" ng-cloak>
-            <strong><%=l 'Error!' %></strong> <%=l 'Backend no available!' %>
+            <strong><%=l 'Error!' %></strong> <%=l 'Backend not available!' %>
         </div>
         <table class="table table-striped">
             <thead>

--- a/templates/main/admin_networks.html.ep
+++ b/templates/main/admin_networks.html.ep
@@ -7,18 +7,20 @@
     <div id="page-wrapper" ng-controller="manage_networks">
     <div id="admin-content">
         <div class="row">
-            <div class="col-md-8"><h2>Networks</h2></div>
+            <div class="col-md-8"><h2><%=l 'Networks' %></h2></div>
             <div class="col-md-4" align="right">
                   <h2><a type="button"
                           class="btn btn-success" href="/network/new">
-                            <b>New Network</b></a>
+                            <b><%=l 'New Network' %></b></a>
                   </h2>
             </div>
         </div>
         <div class="row">
             <div class="col-md-4"></div>
             <!-- <div class="col-md-2">enabled</div> -->
-            <div class="col-md-2">requires password</div>
+            <div class="col-md-2">
+                <%=l 'requires password' %>
+            </div>
         </div>
         <div ng-repeat="network in networks | orderObjectBy:'n_order'"
             class="row"

--- a/templates/main/admin_nodes.html.ep
+++ b/templates/main/admin_nodes.html.ep
@@ -7,10 +7,13 @@
     <div id="page-wrapper" ng-controller="manage_nodes">
       <div id="admin-content" ng-cloak="1">
           <div class="row">
-              <div class="col-md-8"><h2>Nodes</h2></div>
+              <div class="col-md-8"><h2><%=l 'Nodes' %></h2></div>
               <div class="col-md-4" align="right">
-                  <h2><a type="button"
-                          class="btn btn-success" href="/v1/node/new"><b>New Node</b></a>
+                  <h2>
+                    <a type="button"
+                          class="btn btn-success" href="/v1/node/new">
+                            <b><%=l 'New Node' %></b>
+                    </a>
                   </h2>
               </div>
           </div>
@@ -92,13 +95,13 @@
                                 <button type="button" class="close" data-dismiss="modal"
                                     aria-label="Close"><span aria-hidden="true">&times;</span>
                                 </button>
-                                <h4 class="modal-title">Confirm disable node</h4>
+                                <h4 class="modal-title"><%=l 'Confirm disable node' %></h4>
                             </div>
                             <div class="modal-body">
-                                <p>Disabling this node will shut all the
+                                <p><%=l 'Disabling this node will shut all the' %>
                                     {{node.machines.length}}
-                                    machines down.
-                                    Are you sure ?</p>
+                                    <%=l 'machines down.' %>
+                                    <%=l 'Are you sure ?' %></p>
                                 <ul>
                                     <li ng-repeat="machine in node.machines">
                                         {{machine.name}}

--- a/templates/main/admin_settings.html.ep
+++ b/templates/main/admin_settings.html.ep
@@ -11,7 +11,7 @@
     <div class="page-header">
         <div class="card">
             <div class="card-header">
-                <h2>Global Settings</h2>
+                <h2><%=l 'Global Settings' %></h2>
             </div>
         </div>
     </div>
@@ -20,7 +20,7 @@
         <div class="row">
             <div class="col-md-1"></div>
             <div class="col-md-1">
-            <h3>Frontend</h3>
+            <h3><%=l 'Frontend' %></h3>
             </div>
         </div>
         <div class="row" ng-hide="true">
@@ -88,7 +88,7 @@
         <div class="row">
             <div class="col-md-1"></div>
             <div class="col-md-1">
-            <h3>Backend</h3>
+            <h3><%=l 'Backend' %></h3>
             </div>
         </div>
 		<div class="row">
@@ -135,7 +135,7 @@
         <div class="row">
             <div class="col-md-1"></div>
             <div class="col-md-2">
-            <label for="bookings">Bookings</label>
+            <label for="bookings"><%= l 'Bookings' %></label>
             </div>
             <div class="col-md-2">
                 <input name="bookings" ng-model="settings.backend.bookings.value"
@@ -144,7 +144,7 @@
                 >
             </div>
             <div class="col-md-6">
-                Bookings require LDAP authentication. <a href="https://ravada.readthedocs.io/en/latest/docs/auth_ldap.html"><i class="fa fa-info"></i></a>
+                <%=l 'Bookings require LDAP authentication.' %> <a href="https://ravada.readthedocs.io/en/latest/docs/auth_ldap.html"><i class="fa fa-info"></i></a>
             </div>
         </div>
 
@@ -167,7 +167,7 @@
         <div class="row">
             <div class="col-md-1"></div>
             <div class="col-md-2">
-            <label for="debug">Port expose</label>
+            <label for="debug"><%= l 'Port expose' %></label>
             </div>
             <div class="col-md-2">
             <input name="debug" ng-model="settings.backend.expose_port_min.value"
@@ -185,11 +185,11 @@
             <div class="col-md-2">
                 <button ng-click="update_settings()"
                     ng-disabled="!formSettings.$valid || formSettings.$pristine">
-                    save
+                   <%=l 'Save' %>
                 </button>
                 <button ng-click="load_settings()"
                         ng-disabled="formSettings.$pristine">
-                  <%=l 'cancel' %>
+                  <%=l 'Cancel' %>
                 </button>
             </div>
         </div>

--- a/templates/main/machine_access.html.ep
+++ b/templates/main/machine_access.html.ep
@@ -6,7 +6,7 @@
              ,'btn': tab_access !== 'group'
     }"
     ng-model="tab_access_group"
-    ng-click="tab_access='group'">Group</button>
+    ng-click="tab_access='group'"><%=l 'Group' %></button>
 
 
 <button
@@ -16,7 +16,7 @@
              ,'btn': tab_access !== 'client'
     }"
     ng-model="tab_access_client"
-    ng-click="tab_access='client'">Client</button>
+    ng-click="tab_access='client'"><%=l 'Client' %></button>
 
 <button
     class="btn"
@@ -25,7 +25,7 @@
              ,'btn': tab_access !== 'ldap'
     }"
     ng-model="tab_access_ldap"
-    ng-click="tab_access='ldap'">LDAP</button>
+    ng-click="tab_access='ldap'"><%=l 'LDAP' %></button>
 </div>
 
 <div ng-show="tab_access=='group'">

--- a/templates/main/machine_access_client_new.html.ep
+++ b/templates/main/machine_access_client_new.html.ep
@@ -22,7 +22,7 @@
         <input type="button" class="btn btn-primary"
             ng-show="access_attribute['client'] && access_value['client']"
             ng-click="add_access('client')"
-            value="<%=l 'add' %>">
+            value="<%=l 'Add' %>">
     </div>
 </div>
 <ul>

--- a/templates/main/machine_access_client_verify.html.ep
+++ b/templates/main/machine_access_client_verify.html.ep
@@ -1,5 +1,5 @@
 <div class="card alert-info" ng-show="domain_access.length">
-<h4>Client headers
+<h4><%=l 'Client headers' %>
     <span class="badge badge-success"
           ng-show="check_client_access"><%=l 'Accept' %></span>
     <span class="badge badge-danger"

--- a/templates/main/machine_access_ldap_new.html.ep
+++ b/templates/main/machine_access_ldap_new.html.ep
@@ -24,12 +24,12 @@
             ng-show="ldap_attribute && ldap_attribute_value"
             ng-disabled="ldap_verifying"
             ng-click="count_ldap_entries()"
-            value="<%=l 'verify' %>">
+            value="<%=l 'Verify' %>">
         <input type="button" class="btn btn-primary"
             ng-show="ldap_attribute && ldap_attribute_value"
             ng-disabled="ldap_verifying || (!ldap_attribute_allowed && ! ldap_attribute_last)"
             ng-click="add_ldap_access()"
-            value="<%=l 'save' %>">
+            value="<%=l 'Save' %>">
     </div>
 </div>
 <div class="mt-3 alert alert-warning" role="alert"

--- a/templates/main/machine_displays.html.ep
+++ b/templates/main/machine_displays.html.ep
@@ -40,15 +40,15 @@
                 />
                 <i ng-show="password_clipboard"><%=l 'copied to clipboard' %></i>
             </li>
-            <li ng-show="display.display"><b>Display URL :</b>
+            <li ng-show="display.display"><b><%=l 'Display URL :' %></b>
                     <a ng-click="copy_password(display.driver); redirect()"
                         ng-show="display.is_active"
                         href="{{display.display}}">{{display.display}}</a>
                     <i ng-show="!display.is_active" class="fas fa-sync-alt fa-spin"></i>
             </li>
-            <li><b>Display IP :</b> {{display.ip}} </li>
-            <li><b>Display Port :</b> {{display.port}} </li>
-            <li ng-show="display.extra.tls_port"><b>Display Port secure :</b> {{display.extra.tls_port}} </li>
+            <li><b><%=l 'Display IP :' %></b> {{display.ip}} </li>
+            <li><b><%=l 'Display Port :' %></b> {{display.port}} </li>
+            <li ng-show="display.extra.tls_port"><b><%=l 'Display Port secure :' %></b> {{display.extra.tls_port}} </li>
         </ul>
         <div ng-show="domain.is_active && display.is_active && display.file_extension && display.file_extension.length>0">
             <div>

--- a/templates/main/manage_machine_edit_cpu.html.ep
+++ b/templates/main/manage_machine_edit_cpu.html.ep
@@ -92,7 +92,7 @@
                 form_edit.$pristine=false;
                 new_feature='';
                 ">
-                add
+                <%=l 'Add' %>
             </button>
         </div>
     </div><!-- row -->

--- a/templates/main/manage_machine_edit_features.html.ep
+++ b/templates/main/manage_machine_edit_features.html.ep
@@ -10,17 +10,17 @@
         />
         <span ng-show="(feat=='vmport' ||  feat == 'hap')
                     && ( value != '1' && value != '0' )">
-        state
+        <%=l 'state' %>
             <select ng-model="item[feat].state" >
-            <option>on</option>
-            <option>off</option>
+            <option><%=l 'on' %></option>
+            <option><%=l 'off' %></option>
             </select>
         </span>
         <span ng-show="feat == 'kvm' && value != '1' && value != '0'">
-            hidden
+            <%=l 'hidden' %>
             <select ng-model="item[feat].hidden.state">
-                <option>on</option>
-                <option>off</option>
+                <option><%=l 'on' %></option>
+                <option><%=l 'off' %></option>
             </select>
         </span>
         <small>

--- a/templates/main/manage_machine_edit_video.html.ep
+++ b/templates/main/manage_machine_edit_video.html.ep
@@ -15,10 +15,10 @@
             />
         </li>
         <li class="list-group-item" ng-show="!item._primary && item.primary">
-            <span class="info">Primary video devices will move to first</span>
+            <span class="info"><%=l 'Primary video devices will move to first' %></span>
         </li>
         <li class="list-group-item" ng-show="item._primary">
-            <span class="info">Primary can not be unset, enable it in another video device</span>
+            <span class="info"><%=l 'Primary can not be unset, enable it in another video device' %></span>
         </li>
     </ul>
     <ul class="list-group list-group-horizontal-md">

--- a/templates/main/manage_user.html.ep
+++ b/templates/main/manage_user.html.ep
@@ -23,8 +23,8 @@
         <%=l 'This user has never logged in the Ravada server.' %>
         <br/>
 
-    <a class="btn btn-outline-secondary" href="/admin/groups">Cancel</a>
-    <a class="btn btn-primary" href="/admin/user/<%= $user->name %>.html?origin=<%= $origin %>&import=1">Import</a>
+    <a class="btn btn-outline-secondary" href="/admin/groups"><%=l 'Cancel' %></a>
+    <a class="btn btn-primary" href="/admin/user/<%= $user->name %>.html?origin=<%= $origin %>&import=1"><%=l 'Import' %></a>
     </div>
 % }
 
@@ -36,22 +36,22 @@
         <ul class="nav nav-tabs" id="myTab" role="tablist">
 % if ( $_user->is_admin ) {
             <li class="nav-item">
-                <a class="nav-link active" href="#admin" role="tab" data-toggle="tab" aria-controls="admin" aria-selected="true">Admin</a>
+                <a class="nav-link active" href="#admin" role="tab" data-toggle="tab" aria-controls="admin" aria-selected="true"><%=l 'Admin' %></a>
             </li>
 % }
 % if ( $_user->can_grant) {
             <li class="nav-item">
-                <a class="nav-link" href="#grants" role="tab" data-toggle="tab" aria-controls="grants" aria-selected="true">Grants</a>
+                <a class="nav-link" href="#grants" role="tab" data-toggle="tab" aria-controls="grants" aria-selected="true"><%=l 'Grants' %></a>
             </li>
 % }
 % if (( $_user->is_admin ) && (! $user->is_external)) {
             <li class="nav-item">
-                <a class="nav-link" href="#password" role="tab" data-toggle="tab" aria-controls="password" aria-selected="true">Password</a>
+                <a class="nav-link" href="#password" role="tab" data-toggle="tab" aria-controls="password" aria-selected="true"><%=l 'Password' %></a>
             </li>
 % }
 % if ( $_user->is_admin && $user->is_external && $user->external_auth eq 'ldap' && $user->ldap_entry ) {
             <li class="nav-item">
-                <a class="nav-link" href="#groups" role="tab" data-toggle="tab" aria-controls="groups" aria-selected="true">Groups</a>
+                <a class="nav-link" href="#groups" role="tab" data-toggle="tab" aria-controls="groups" aria-selected="true"><%=l 'Groups' %></a>
             </li>
 % }
 

--- a/templates/main/network_machines.html.ep
+++ b/templates/main/network_machines.html.ep
@@ -63,12 +63,12 @@
 
         <div ng-show="machine.anonymous == 1 && machine.allowed== 0"
             class="alert alert-warning">
-          Warning: anonymous machines won't show up unless you enable allowed.
+            <%=l 'Warning: anonymous machines won\'t show up unless you enable allowed.' %>
         </div>
 
         <div ng-show="machine.anonymous == 1 && machine.is_public == 0"
             class="alert alert-warning">
-                Warning: anonymous machines won't show up unless you set them public.
+            <%=l 'Warning: anonymous machines won\'t show up unless you set them public.' %>
         </div>
 
     </div>

--- a/templates/main/network_new.html.ep
+++ b/templates/main/network_new.html.ep
@@ -12,7 +12,7 @@
              ng-init="init()"
         >
         <div class="card-header">
-            <h2>New network</h2>
+            <h2><%=l 'New network' %></h2>
         </div>
         <div class="card-body">
 %=          include '/main/network_options'

--- a/templates/main/network_options.html.ep
+++ b/templates/main/network_options.html.ep
@@ -1,7 +1,7 @@
 <div class="container-fluid" ng-hide="new_saved">
 <form name="formNetwork">
 <div class="row">
-    <div class="col-md-3" align="right">name</div>
+    <div class="col-md-3" align="right"><%=l 'name' %></div>
     <div class="col-md-8">
         <input type="text" name="name" ng-model="network.name" required
             ng-change='check_duplicate("name")'
@@ -16,25 +16,25 @@
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">address</div>
+    <div class="col-md-3" align="right"><%=l 'address' %></div>
     <div class="col-md-8" align="left">
         <input type="text" name="address" ng-model="network.address" required ipaddress
             ng-change='check_duplicate("address")'
         >
-        <span ng-show="formNetwork.address.$error.required">Network address is required.</span>
-        <span ng-show="formNetwork.$error.ipformat">Invalid IP network address. Expecting a.b.c.d/e</span>
-        <span ng-show="network._duplicated_address">This address is duplicated</span>
+        <span ng-show="formNetwork.address.$error.required"><%=l 'Network address is required.' %></span>
+        <span ng-show="formNetwork.$error.ipformat"><%=l 'Invalid IP network address. Expecting a.b.c.d/e' %></span>
+        <span ng-show="network._duplicated_address"><%=l 'This address is duplicated' %></span>
     </div>
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">password</div>
+    <div class="col-md-3" align="right"><%=l 'password' %></div>
     <div class="col-md-1" align="left">
         <input type="checkbox" name="address" ng-model="network.requires_password"
             ng-true-value="1" ng-false-value="0"
         >
     </div>
-    <div class="col-md-8">Requires viewer password when implemented</div>
+    <div class="col-md-8"><%=l 'Requires viewer password when implemented' %></div>
 </div>
 
 <div class="row">
@@ -47,18 +47,18 @@
             ng-change="check_all_domains()"
         >
     </div>
-    <div class="col-md-8">Users from this network can run all virtual machines</div>
+    <div class="col-md-8"><%=l 'Users from this network can run all virtual machines' %></div>
 </div>
 
 <div class="row">
-    <div class="col-md-3" align="right">No machines</div>
+    <div class="col-md-3" align="right"><%=l 'No machines' %></div>
     <div class="col-md-1" align="left">
         <input type="checkbox" name="address" ng-model="network.no_domains"
             ng-true-value="1" ng-false-value="0"
             ng-change="check_no_domains()"
         >
     </div>
-    <div class="col-md-8">Users from this network can run no virtual machines</div>
+    <div class="col-md-8"><%=l 'Users from this network can run no virtual machines' %></div>
 </div>
 
 
@@ -67,7 +67,7 @@
     <div class="col-md-4" align="left">
         <button ng-show="network.id" class="btn btn-outline-secondary"
             ng-disabled="formNetwork.$pristine"
-        ng-click="load_network(network.id)">cancel</button>
+        ng-click="load_network(network.id)"><%=l 'Cancel' %></button>
         <button
             class="btn btn-primary"
             ng-click="update_network()"
@@ -75,10 +75,10 @@
             || (!network.all_domains && !network.no_domains)
             || network._duplicated_name
             || network._duplicated_address
-            ">save</button>
+            "><%=l 'Save' %></button>
     </div>
     <div ng-show="!network.all_domains && !network.no_domains">
-        Set either <i>all machines</i> or <i>no machines</i> for users in this network
+        <%=l 'Set either' %> <i><%=l 'all machines' %></i> <%=l 'or' %> <i><%=l 'no machines' %></i> <%=l 'for users in this network' %>
     </div>
 </div>
 
@@ -87,6 +87,6 @@
 
 <div class="row">
     <div class="col-md-8 alert alert-info" ng-show="saved && formNetwork.$pristine">
-        Network {{network.name}} saved.
+        <%=l 'Network' %> {{network.name}} <%=l 'saved.' %>
     </div>
 </div>

--- a/templates/main/network_remove.html.ep
+++ b/templates/main/network_remove.html.ep
@@ -1,8 +1,8 @@
 <div ng-show="network && network.id">
-    Are you sure you want to remove the <%= $item %> {{network.name}}
+    <%=l 'Are you sure you want to remove the' %> <%= $item %> {{network.name}}
 
-    <button ng-click="remove_network(network.id)"><%=l 'yes' %></button>
-    <button onclick="location='/admin/networks'"><%=l 'cancel' %></button>
+    <button ng-click="remove_network(network.id)"><%=l 'Yes' %></button>
+    <button onclick="location='/admin/networks'"><%=l 'Cancel' %></button>
 </div>
 
 <div ng-show="message">{{message}}</div>

--- a/templates/main/new_node.html.ep
+++ b/templates/main/new_node.html.ep
@@ -15,7 +15,7 @@
                     action="/v1/node/new">
                 <div class="form-group row">
                 <label for="vm_type" class="col-lg-2 control-label"><%=l 'Backend' %> <a
-                  title="Choose the virtualization type of the Node."><i class="fa fa-info-circle"></i></a></label>
+                  title="<%=l 'Choose the virtualization type of the Node.' %>"><i class="fa fa-info-circle"></i></a></label>
                     <div class="col-lg-3">
                         <select class= "form-control"
                         name="vm_type"
@@ -44,7 +44,7 @@
 
                     <a type="button" class="btn btn-warning" ng-show="vm_type && hostname"
                                                      ng-click="connect_node(vm_type,hostname)">
-                        Check connection to {{hostname}}
+                        <%=l 'Check connection to' %> {{hostname}}
                     </a>
                     <!--<small class="form-text text-muted">Format: 192.168.0.1/32</small> -->
                 </div>
@@ -76,7 +76,7 @@
             </div>
             <div ng-show="request || id_req" class=" form-group row border border-primary">
             <div class="d-flex p-2 bd-highlight bg-light text-dark">
-                <div ng-show="id_req && !request">Testing connection to ̣{{hostname}}</div>
+                <div ng-show="id_req && !request"><%=l 'Testing connection to' %> ̣{{hostname}}</div>
                 <div ng-show="request">{{request.error || "Waiting ... "}}</div>
             </div>
             </div>

--- a/templates/main/node_bases.html.ep
+++ b/templates/main/node_bases.html.ep
@@ -11,7 +11,7 @@
         ng-disabled="base.clones>0 && node.is_local"
         ng-true-value="1" ng-false-value="0"
         ng-change="set_base_vm(base.id, base.enabled)"
-        title="This base has {{base.clones}} clones"
+        title="<%= l 'This base has' %> {{base.clones}} <%= l 'clones' %>"
         >
     </div>
 

--- a/templates/main/node_options.html.ep
+++ b/templates/main/node_options.html.ep
@@ -61,13 +61,13 @@
     <div class="col-md-3" align="right"></div>
     <div class="col-md-4" align="left">
         <button ng-show="node.id" class="btn btn-outline-secondary"
-            ng-click="load_node()"><%=l 'cancel' %></button>
+            ng-click="load_node()"><%=l 'Cancel' %></button>
         <button class="btn btn-primary"
             ng-click="update_node()"
             ng-disabled="!formNode.$valid || formNode.$pristine
             || node._duplicated_name
             || node._duplicated_address
-            ">save</button>
+            "><%=l 'Save' %></button>
     </div>
 </div>
 
@@ -75,7 +75,7 @@
 
 <div class="row">
     <div class="col-md-8 alert alert-info" ng-show="saved && formNode.$pristine">
-        Node {{node.name}} saved.
+        <%=l 'Node' %> {{node.name}} <%=l 'saved.' %>
     </div>
     <div class="col-md-8 alert alert-danger" ng-show="error">
         {{error}}

--- a/templates/main/node_remove.html.ep
+++ b/templates/main/node_remove.html.ep
@@ -1,19 +1,19 @@
 <div ng-show="node.is_local">
-    This is a main node and can't be removed.
+    <%=l 'This is a main node and can\'t be removed.' %>
 </div>
 
 <div ng-hide="!node.id || node.is_local">
 
     <div class="row">
         <div class="col-md-8">
-        Are you sure you want to remove the node {{node.name}} ?
+        <%=l 'Are you sure you want to remove the node' %> {{node.name}} ?
         </div>
     </div>
 
     <div class="row" ng-show="node.has_bases">
         <div class="col-md-8">
-        This node has {{node.has_bases}} bases.<br/>
-        <input type="checkbox" ng-model="remove_bases"> Remove bases in node
+        <%=l 'This node has' %> {{node.has_bases}} <%=l 'bases.' %><br/>
+        <input type="checkbox" ng-model="remove_bases"> <%=l 'Remove bases in node' %>
         </div>
     </div>
 
@@ -22,7 +22,7 @@
         <div class="col-md-8">
         <button ng-disabled="node.has_bases && !remove_bases"
             ng-click="remove_node(node.id)"
-        >Yes</button>
+        ><%=l 'Yes' %></button>
 
         <button onclick="location='/admin/nodes'"><%=l 'Cancel' %></button>
         </div>

--- a/templates/main/pending_request.html.ep
+++ b/templates/main/pending_request.html.ep
@@ -1,5 +1,5 @@
 <div ng-show="pending_request" class="alert alert-warning">
-    Request {{pending_request.command_text}} {{showmachine.name}} {{pending_request.status}}.
+    <%=l 'Request' %> {{pending_request.command_text}} {{showmachine.name}} {{pending_request.status}}.
     <br/>
     {{pending_request.error}}
 </div>

--- a/templates/main/remove_machine.html.ep
+++ b/templates/main/remove_machine.html.ep
@@ -9,19 +9,19 @@
         <div class="page-header">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <h2>Removing Virtual Machine <%= $domain->name %> ?</h2>
+                    <h2><%=l 'Removing Virtual Machine' %> <%= $domain->name %> ?</h2>
                 </div>
                 <form method="post" action="/machine/remove/<%= $domain->id %>.html">
                     <p>
-                    <b>This can't be undone</b> and will remove all the disk and information
-                    of this virtual machine.
+                    <b><%=l 'This can\'t be undone' %></b>
+                    <%=l 'and will remove all the disk and information of this virtual machine.' %>
                     </p>
                     <p>
-                        Are you sure ?
-                        <input type="text" name="sure"><font color="red"> Please insert <b>yes</b> or <b>not</b> to apply.</font>
+                        <%=l 'Are you sure ?' %>
+                        <input type="text" name="sure"><font color="red"> <%=l 'Please insert' %> <b><%=l 'yes' %></b> <%=l 'or' %> <b><%=l 'not' %></b> <%=l 'to apply.' %></font>
                     </p>
-                    <input type="submit" name="Remove" value="Remove">
-                    <input type="submit" name="cancel" value="Cancel">
+                    <input type="submit" name="Remove" value="<%=l 'Remove' %>">
+                    <input type="submit" name="cancel" value="<%=l 'Cancel' %>">
                 </form>
             </div>
         </div>

--- a/templates/main/request.html.ep
+++ b/templates/main/request.html.ep
@@ -12,9 +12,9 @@
             <div class="page-header">
                 <div class="card">
                     <div class="card-header">
-                        <h2>Request <%= $request->{command} %> <%= $request->args->{name} %> <%= $request->{status} %></h2>
+                        <h2><%=l 'Request' %> <%= $request->{command} %> <%= $request->args->{name} %> <%= $request->{status} %></h2>
                         <p>
-                            <a href="/request/<%= $request->{id} %>.html">Refresh</a>
+                            <a href="/request/<%= $request->{id} %>.html"><%=l 'Refresh' %></a>
                         </p>
                     </div>
                     <p><%= Data::Dumper::Dumper($request) %></p>

--- a/templates/main/run_request.html.ep
+++ b/templates/main/run_request.html.ep
@@ -40,7 +40,7 @@
                 <li ng-show="domain.interfaces"><b><%=l 'Hardware address' %></b> {{domain.interfaces[0].hwaddr}} </li>
                 <li><b><%=l 'Max Memory' %>:</b> {{domain.max_mem}}</li>
                 <li><b><%=l 'Memory' %>:</b> {{domain.memory}}</li>
-                <li><b>CPUs:</b> {{domain.nrVirtCpu}}</li>
+                <li><b><%=l 'CPUs' %>:</b> {{domain.nrVirtCpu}}</li>
             </ul>
             <div class="list-group list-group-horizontal-md"
                 ng-show="domain.ports.length">
@@ -65,8 +65,8 @@
             <table border="0">
                 <tr ng-repeat="port in domain.ports">
                     <td align="right">
-                    <span ng-show="!port.is_active" class="badge badge-danger">down</span>
-                    <span ng-show="port.is_active" class="badge badge-info">up
+                    <span ng-show="!port.is_active" class="badge badge-danger"><%=l 'down' %></span>
+                    <span ng-show="port.is_active" class="badge badge-info"><%=l 'up' %>
                     </span>
                     </td>
                     <td align="left">

--- a/templates/main/settings_generic_tabs.html.ep
+++ b/templates/main/settings_generic_tabs.html.ep
@@ -5,7 +5,7 @@
 % my $tabs = $tabs_item{$item};
 
 % if (!$tabs) {
-    <b>Error:</b> I don't know settings tabs for $item
+    <b><%=l 'Error:' %></b> <%=l 'I don\'t know settings tabs for:' %> $item
 % }
 
 % my $active="active";

--- a/templates/main/settings_machine_tabs_head.html.ep
+++ b/templates/main/settings_machine_tabs_head.html.ep
@@ -21,7 +21,7 @@
         <a class="nav-link" id="v-pills-graphics-tab" ng-click="refresh_machine()" href="#v-pills-graphics" data-toggle="pill" role="tab" aria-controls="v-pills-graphics" aria-selected="false"><%=l 'Graphics' %></a>
     %   }
     %   if ($USER->is_admin && !$domain->is_volatile) {
-        <a class="nav-link" id="v-pills-base-tab" href="#v-pills-base" data-toggle="pill" role="tab" aria-controls="v-pills-base" aria-selected="false">Base</a>
+        <a class="nav-link" id="v-pills-base-tab" href="#v-pills-base" data-toggle="pill" role="tab" aria-controls="v-pills-base" aria-selected="false"><%=l 'Base' %></a>
     %   }
     %   if ($USER->is_admin || $USER->can_clone_all ){
         <a class="nav-link" id="v-pills-copy-tab" ng-click="refresh_machine()" href="#v-pills-copy" data-toggle="pill" role="tab" aria-controls="v-pills-copy" aria-selected="false"><%=l 'Copy' %></a>

--- a/templates/main/vm_actions.html.ep
+++ b/templates/main/vm_actions.html.ep
@@ -93,7 +93,7 @@
     <div class="col-md-7">
         <div><%=l 'Compact disk volumes' %></div>
         <div ng-show="showmachine.is_compacted">
-            This virtual machine has already been compacted
+            <%=l 'This virtual machine has already been compacted' %>
         </div>
     </div>
   </div>

--- a/templates/main/vm_base.html.ep
+++ b/templates/main/vm_base.html.ep
@@ -1,15 +1,15 @@
 <div class="card-body">
     <div class="alert alert-success" ng-show="domain.is_locked">
-        <%=l 'This machine is locked by process' %> <a href="/request/{{domain.is_locked}}.html">process</a>
+        <%=l 'This machine is locked by process' %> <a href="/request/{{domain.is_locked}}.html"><%=l 'process' %></a>
     </div>
     <div class="alert alert-warning" ng-show="domain.has_clones">
         <%=l 'This base can\'t be removed because the domain has clones.' %>
     </div>
 
     <div ng-hide="showmachine || (pending_request && pending_request.status != 'done')">
-        Loading machine <i class="fas fa-sync-alt fa-spin"></i>
+        <%=l 'Loading machine' %> <i class="fas fa-sync-alt fa-spin"></i>
         <div ng-show="pending_request && pending_request.status !='done'">
-            waiting for requests {{pending_request}}
+            <%=l 'waiting for requests' %> {{pending_request}}
         </div>
     </div>
 
@@ -29,12 +29,12 @@
 </div>
 
 <div ng-show="showmachine.is_base && !nodes">
-Loading nodes <i class="fas fa-sync-alt fa-spin"></i>
+<%=l 'Loading nodes' %> <i class="fas fa-sync-alt fa-spin"></i>
 </div>
 
 <div ng-show="showmachine.is_base && nodes && nodes.length>1">
 <hr>
-<h4>Nodes</h4>
+<h4><%=l 'Nodes' %></h4>
 
 <div class="row" ng-repeat="node in nodes">
     <div class="col-md-1" ng-show="{{node.type == showmachine.type}}">
@@ -48,10 +48,10 @@ Loading nodes <i class="fas fa-sync-alt fa-spin"></i>
         {{node.name}}
     </div>
     <div class="col-md-4" ng-show="{{node.type == showmachine.type}}">
-        <div ng-hide="node.is_active">Node down</div>
-        <div ng-hide="node.enabled">Node disabled</div>
-        <div ng-show="node.is_local && showmachine.has_clones">This base has clones</div>
-        <div ng-show="!node.is_local && showmachine.clones[node.id]">This node has {{ showmachine.clones[node.id].length }} clones</div>
+        <div ng-hide="node.is_active"><%=l 'Node down' %></div>
+        <div ng-hide="node.enabled"><%=l 'Node disabled' %></div>
+        <div ng-show="node.is_local && showmachine.has_clones"><%=l 'This base has clones' %></div>
+        <div ng-show="!node.is_local && showmachine.clones[node.id]"><%=l 'This node has' %> {{ showmachine.clones[node.id].length }} <%=l 'clones' %></div>
     </div>
 </div>
 </div>

--- a/templates/main/vm_booking.html.ep
+++ b/templates/main/vm_booking.html.ep
@@ -1,4 +1,4 @@
-<h1>Bookings</h1>
+<h1><%=l 'Bookings' %></h1>
 
 <div ng-hide="new_booking">
 <button class="btn btn-success" ng-click="init_new_booking()">

--- a/templates/main/vm_booking_list.html.ep
+++ b/templates/main/vm_booking_list.html.ep
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col">
-        <button ng-click="today()">today</button>
+        <button ng-click="today()"><%=l 'today' %></button>
 
         <button ng-click="previous()">
             <i class="fa fa-arrow-left" aria-hidden="true"></i>
@@ -13,7 +13,7 @@
         <big>{{booking_monday.getMonth()+1}} {{booking_monday.getFullYear() }}</big>
     </div>
     <div class="col" align="right">
-        <a type ="button" class="btn btn-success" href="/booking/new.html">Crea</a>
+        <a type ="button" class="btn btn-success" href="/booking/new.html"><%=l 'Create' %></a>
     </div>
 </div>
 
@@ -21,7 +21,7 @@
 <div class="containter" ng-cloak="1">
 
 <div class="row">
-    <div class="col col-xl-1">time</div>
+    <div class="col col-xl-1"><%=l 'Time' %></div>
     <div class="col col-xl-1" ng-repeat="day in week">
         <small ng-class='{"today1": day.is_today }'>{{day.dow}}</small><br/>
         <span  ng-class='{"today2": day.is_today }'>{{day.day}}</span>

--- a/templates/main/vm_booking_new.html.ep
+++ b/templates/main/vm_booking_new.html.ep
@@ -65,14 +65,14 @@ my %dow = (
 
 <div class="row">
     <div class="col-md-2">
-        Group
+        <%=l 'Group' %>
     </div>
     <div class="col-md-2">
         <select ng-options="name for name in ldap_groups"
         ng-model="booking.ldap_groups" required></select>
     </div>
     <div class="col-md-2">
-        <span class="badge badge-primary"><%=l 'add' %></span>
+        <span class="badge badge-primary"><%=l 'Add' %></span>
     </div>
 </div>
 
@@ -81,7 +81,7 @@ my %dow = (
             <button ng-click="save_booking()"
                     ng-disabled="!form_booking.$valid || form_booking.$pristine
                         || booking.day_of_week == '0000000'">
-              <%=l 'save' %>
+              <%=l 'Save' %>
             </button>
     </div>
 </div>

--- a/templates/main/vm_copy.html.ep
+++ b/templates/main/vm_copy.html.ep
@@ -2,7 +2,7 @@
         <div class="form-group">
             <div class="form-group row">
                 <div class="col-md-2 mt-2">
-                    <label class="control-label" for="clone_number">Clones</label>
+                    <label class="control-label" for="clone_number"><%=l 'Clones' %></label>
                 </div>
                 <div class="col-md-2">
                     <input class="form-control"
@@ -27,7 +27,7 @@
             </div>
             <div class="form-group row">
                 <div class="col-md-2 mt-2">
-                    <label class="control-label" for="copy_ram">RAM (Gb)</label>
+                    <label class="control-label" for="copy_ram"><%=l 'RAM (Gb)' %></label>
                 </div>
                 <div class="col-md-2">
                     <input class="form-control" ng-model="copy_ram" type="text" size="3">
@@ -69,12 +69,12 @@
     <div class="form-group has-error">
         <label ng-show="copy_number==1 && new_name_duplicated"
                class="alert alert-danger col-form-label" for="new_name">
-               This name is duplicated
+               <%=l 'This name is duplicated' %>
         </label>
         <label ng-show="copy_number==1 && new_name_invalid"
                class="alert alert-danger col-form-label" for="new_name">
-               This name is invalid. It can only contain alphabetic, numbers, undercores and dashes
-               and must start by a letter.
+               <%=l 'This name is invalid. It can only contain alphabetic, numbers, undercores and dashes
+               and must start by a letter.' %>
         </label>
     </div>
 </div>

--- a/templates/main/vm_description.html.ep
+++ b/templates/main/vm_description.html.ep
@@ -6,7 +6,7 @@
                     <div class="form-group">
                         <strong><label for="description"><%=l 'This information will be available to the users' %>.</label></strong>
                         <br/>
-                        <textarea id="editor" name="description" style="width: 100%;" placeholder="Description"><%= $domain->description %></textarea>
+                        <textarea id="editor" name="description" style="width: 100%;" placeholder="<%=l 'Description' %>"><%= $domain->description %></textarea>
                         <script>
                             CKEDITOR.replace( 'editor', {height: 200} );
                         </script>

--- a/templates/main/vm_drivers.html.ep
+++ b/templates/main/vm_drivers.html.ep
@@ -7,7 +7,7 @@
 % );
 
     <div class="row" ng-hide="pending_requests > 0">
-        <div class="col-md-6"></div><div class="col-md-2"><span class="badge badge-info">recommended</span></div>
+        <div class="col-md-6"></div><div class="col-md-2"><span class="badge badge-info"><%=l 'recommended' %></span></div>
     </div>
 
     <div ng-hide="pending_requests > 0" class="form-group">
@@ -15,7 +15,7 @@
 %       for my $driver_name (qw(network sound video)) {
 %           my $driver = $domain->drivers($driver_name);
 %           if (!$driver) {
-                <b>I can't find <%= $driver_name %> driver</b>
+                <b><%=l 'I can\'t find' %> <%= $driver_name %> <%=l 'driver' %></b>
 %               next;
 %           }
         <div class="row">

--- a/templates/main/vm_hardware.html.ep
+++ b/templates/main/vm_hardware.html.ep
@@ -1,9 +1,9 @@
 <div class="panel-body" ng-show="showmachine.is_active || showmachine.is_base">
     <div ng-show="showmachine.is_active" class="alert alert-danger" role="alert">
-        This machine is running and can't be modified.
+        <%=l 'This machine is running and can\'t be modified.' %>
     </div>
     <div ng-show="showmachine.is_base" class="alert alert-danger" role="alert">
-        This machine is base and can't be modified.
+        <%=l 'This machine is base and can\'t be modified.' %>
     </div>
 </div>
 <div>
@@ -34,10 +34,10 @@
                     ng-class='{"border border-danger p-4 m-4": item.device == "disk"}'
                 >
                         <p class="h4" ng-show="item.device == 'disk'">
-                            Danger: This will destroy all the disk data permantently.
+                            <%=l 'Danger: This will destroy all the disk data permantently.' %>
                         </p>
                     <label for="confirm_remove">
-                        Type the name of the volume disk to confirm:
+                        <%=l 'Type the name of the volume disk to confirm:' %>
                     </label>
                     <input name="confirm_remove" ng-model="confirm_remove" type="text"
                         ng-value=""
@@ -70,7 +70,7 @@
                 ng-disabled="(showmachine._date_changed && showmachine.requests > 0 ) || showmachine.is_base || showmachine.is_active"
                 ng-click="add_hardware(new_hardware)"
                 type="button">
-            <%=l 'Add'%></button>
+            <%=l 'Add' %></button>
         </div>
         <div class="custom-file">
             <select class="custom-select" ng-model="new_hardware"

--- a/templates/main/vm_locked_is_base.html.ep
+++ b/templates/main/vm_locked_is_base.html.ep
@@ -1,5 +1,5 @@
 <div class="panel-body">
 <div class="panel panel-warning">
-    <div class="panel-heading">This machine is base and it can't be modified.</div>
+    <div class="panel-heading"><%=l 'This machine is base and it can\'t be modified.' %></div>
 </div>
 </div>

--- a/templates/main/vm_monitoring.html.ep
+++ b/templates/main/vm_monitoring.html.ep
@@ -4,7 +4,7 @@
     <div class="form-group">
 %   if ( ($domain->internal_id) < 1) {
     <div class="alert alert-info">
-        The VM is <strong>stopped</strong>. Nothing to monitoring
+        <%=l 'The VM is' %> <strong><%=l 'stopped' %></strong>. <%=l 'Nothing to monitoring' %>
     </div>
 %   } else {
     <div data-netdata="cgroup_qemu_qemu_<%= $domain->internal_id %>-<%= lc($domain->name) %>.cpu"></div>

--- a/templates/main/vm_options.html.ep
+++ b/templates/main/vm_options.html.ep
@@ -15,13 +15,13 @@
 
             <div class="row" ng-show="!nodes && (showmachine && !showmachine.is_base)">
                 <div class="col-lg-3 mt-2">
-                    Loading nodes <i class="fas fa-sync-alt fa-spin"></i>
+                    <%=l 'Loading nodes' %> <i class="fas fa-sync-alt fa-spin"></i>
                 </div>
             </div>
 
             <div class="row" ng-show="!showmachine.is_base && nodes.length>1">
                 <div class="col-lg-3 mt-2">
-                    Node
+                    <%=l 'Node' %>
                 </div>
                 <div class="col-lg-3 mt-2">
                     <select ng-model="new_node"
@@ -43,12 +43,12 @@
                         <label for="start"><%=l 'Start after migration' %></label>
                     </div>
                     <div ng-show="showmachine.is_active">
-                        This virtual machine is running. It must be shut down before
-                        migrate.
+                        <%=l 'This virtual machine is running. It must be shut down before
+                        migrate.' %>
                     </div>
                     <div>
-                        Are you sure you want to migrate {{showmachine.name}}
-                        to {{new_node.name}} ?
+                        <%=l 'Are you sure you want to migrate' %> {{showmachine.name}}
+                        <%=l 'to.' %> {{new_node.name}} ?
                     </div>
                     <div>
                     <button type="button" class="btn btn-primary"
@@ -162,7 +162,7 @@
             </div>
             <div class="row" ng-hide="showmachine.is_base">
                 <div class="col-lg-3 mt-2">
-                    <label class="control-label" for="autostart"><%=l 'Auto Start' %></label>
+                    <label class="control-label" for="autostart"><%=l 'Autostart' %></label>
                 </div>
                 <div class="col-lg-2">
                     <input type="checkbox" ng-model="new_autostart" name="autostart"
@@ -190,7 +190,7 @@
                     >
                 </div>
                 <div class="col-md-7"><small class="text-secondary">
-                    <%=l 'Virtual Machine will be shut down when user disconnects.' %></small>
+                    <%=l 'Virtual Machine will be shutdown when user disconnects.' %></small>
                 </div>
             </div>
 

--- a/templates/main/vm_pool.html.ep
+++ b/templates/main/vm_pool.html.ep
@@ -60,8 +60,8 @@
                 </div>
                 <div ng-show="showmachine.pool_start > showmachine.pool_clones"
                     class="alert alert-danger"
-                >Error: you want to have {{showmachine.pool_start}} but there are
-                    only {{showmachine.pool_clones}} clones defined.
+                ><%=l 'Error: you want to have' %> {{showmachine.pool_start}} <%=l 'but there are
+                    only' %> {{showmachine.pool_clones}} <%=l 'clones defined.' %>
                 </div>
              </div>
          </div>
@@ -69,7 +69,7 @@
     <div class="panel-body" ng-show="!showmachine.is_base && showmachine.id_base">
         <div class="row">
             <div class="col-md-2">
-               Pool
+               <%=l 'Pool' %>
             </div>
             <div class="col-md-2">
                 <input type="checkbox" ng-checked="showmachine.is_pool==1"

--- a/templates/main/vm_ports.html.ep
+++ b/templates/main/vm_ports.html.ep
@@ -1,18 +1,18 @@
 <div class="card-body">
      <div class="row">
         <div class="col-lg-2 mt-2">
-             Port
+             <%=l 'Port' %>
         </div>
         <div class="col-lg-2 mt-2">
-             Restricted
+             <%=l 'Restricted' %>
         </div>
         <div class="col-lg-4 mt-2">
-            Name
+            <%=l 'Name' %>
         </div>
         <div class="col-lg-2 mt-2">
-             Public Port
+             <%=l 'Public Port' %>
         </div>
-        <div class="col-lg-2 mt-2">Action</div>
+        <div class="col-lg-2 mt-2"><%=l 'Action' %></div>
      </div>
 
      <div class="row">
@@ -21,7 +21,7 @@
         </div>
         <div class="col-lg-2 mt-2">
             <input type="checkbox" ng-model="new_port_restricted"
-                title="Only remote client can access this port if restricted"
+                title="<%=l 'Only remote client can access this port if restricted' %>"
             >
         </div>
         <div class="col-lg-4 mt-2">
@@ -39,18 +39,18 @@
          <div class="col-lg-2 mt-2">
             {{port.internal_port}}
             <span ng-show="showmachine.is_active && !port.is_active"
-                class="badge badge-danger">down</span>
+                class="badge badge-danger"><%=l 'down' %></span>
             <span ng-show="showmachine.is_active && port.is_active"
-                class="badge badge-info">up</span>
+                class="badge badge-info"><%=l 'up' %></span>
          </div>
         <div class="col-lg-2 mt-2">
             <input type="checkbox" ng-show="port.restricted == 1" checked
                 ng-click="expose(port.internal_port, port.name, 0, port.id)"
-                title="Only remote client can access this port"
+                title="<%=l 'Only remote client can access this port' %>"
             >
             <input type="checkbox" ng-show="port.restricted != 1"
                 ng-click="expose(port.internal_port, port.name, 1, port.id)"
-                title="Any remote client can access this port"
+                title="<%=l 'Any remote client can access this port' %>"
             >
         </div>
          <div class="col-lg-4 mt-2">
@@ -66,7 +66,7 @@
 
     <button ng-show="showmachine.is_active"
         ng-click="request('refresh_machine_ports',{ id_domain: showmachine.id , retry: 10 } )"
-        >Refresh ports</button>
+        ><%=l 'Refresh ports' %></button>
     <br/>
 
 </div>

--- a/templates/main/vm_rebase.html.ep
+++ b/templates/main/vm_rebase.html.ep
@@ -2,7 +2,7 @@
 
     <div ng-show="bases" class="row">
         <div class="col-md-1">
-            <label>Base</label>
+            <label><%=l 'Base' %></label>
         </div>
         <div class="col-md-11">
             <select ng-model="new_base"
@@ -12,19 +12,19 @@
             <button class="btn btn-primary"
             ng-click="change_base=true"
             ng-show="new_base && new_base.id != showmachine.id_base && new_base.id !=showmachine.id"
-            >Change</button>
+            ><%=l 'Change' %></button>
             <button class="btn btn-outline-secondary"
                 ng-click="new_base=undefined;list_bases()"
                 ng-show="new_base && new_base.id != showmachine.id_base && new_base.id !=showmachine.id"
-            >Cancel</button>
+            ><%=l 'Cancel' %></button>
         </div>
     </div>
     <div ng-show="bases" class="row">
         <div class="col-md-1">
         </div>
         <div class="col-md-11">
-            <p ng-show="showmachine.is_base">Rebase all the clones to a new base</p>
-            <p ng-show="showmachine.id_base && !showmachine.has_clones">Rebase this machine to another virtual machine</p>
+            <p ng-show="showmachine.is_base"><%=l 'Rebase all the clones to a new base' %></p>
+            <p ng-show="showmachine.id_base && !showmachine.has_clones"><%=l 'Rebase this machine to another virtual machine' %></p>
         </div>
     </div>
     <div ng-show="bases" class="row">
@@ -32,19 +32,19 @@
             && (showmachine.is_base || showmachine.id_base != new_base_id)"
             class="alert alert-danger">
 
-            <h3>Warning</h3>
+            <h3><%=l 'Warning' %></h3>
             <p>
-                Changing the base of a virtual machine is potentially dangerous
-                and can't be undone.
+                <%=l 'Changing the base of a virtual machine is potentially dangerous
+                and can\'t be undone.' %>
             </p>
-            <p>Are you sure ?
+            <p><%=l 'Are you sure ?' %>
                 <button class="btn btn-primary" ng-click="change_base=false;list_bases()"
-                >No, cancel</button>
-                <button class="btn btn-danger" ng-click="rebase();change_base=false">Yes, rebase</button>
+                ><%=l 'No, cancel' %></button>
+                <button class="btn btn-danger" ng-click="rebase();change_base=false"><%=l 'Yes, rebase' %></button>
             </p>
         </div>
         <div ng-show="rebase_request" class="alert alert-warning">
-             Rebase {{rebase_request.command}} {{showmachine.name}} to {{req_new_base.name}} {{rebase_request.status}}.
+             <%=l 'Rebase' %> {{rebase_request.command}} {{showmachine.name}} <%=l 'to' %> {{req_new_base.name}} {{rebase_request.status}}.
             <br/>
             {{rebase_request.error}}
         </div>

--- a/templates/main/vm_rename.html.ep
+++ b/templates/main/vm_rename.html.ep
@@ -3,10 +3,10 @@
         <div class="form-group-row">
             <div class="col-md-12">
                 <div class="alert alert-danger" role="alert" ng-show="showmachine.is_active">
-                   This machine is running and can't be renamed.
+                   <%=l 'This machine is running and can\'t be renamed.' %>
                 </div>
                 <div class="alert alert-danger" role="alert" ng-show="showmachine.is_hibernated">
-                   This machine is hibernated and can't be renamed.
+                   <%=l 'This machine is hibernated and can\'t be renamed.' %>
                 </div>
             </div>
             <div class="col-md-5">
@@ -30,7 +30,7 @@
         </div>
         <div class="form-group">
             <div class="col-md-5 alert alert-warning" ng-show="rename_request">
-                Rename {{shownamchine.name}} {{rename_request.status}}.
+                <%=l 'Rename' %> {{shownamchine.name}} {{rename_request.status}}.
                 <br/>
                 {{rename_request.error}}
             </div>
@@ -38,11 +38,11 @@
         <div class="form-group has-error" ng-show="new_name_duplicated || new_name_invalid">
             <div class="alert alert-danger col-form-label" role="alert">
                 <div ng-show="new_name_duplicated">
-                    This name is duplicated
+                    <%=l 'This name is duplicated' %>
                 </div>
                 <div ng-show="new_name_invalid">
-                       This name is invalid. It can only contain alphabetic, numbers, undercores and dashes
-                       and must start by a letter.
+                       <%=l 'This name is invalid. It can only contain alphabetic, numbers, undercores and dashes
+                       and must start by a letter.' %>
                 </div>
             </div>
         </div>

--- a/templates/main/vm_spinoff.html.ep
+++ b/templates/main/vm_spinoff.html.ep
@@ -5,12 +5,12 @@
     </div>
     <div class="col-sm-8" ng-hide="confirm_spinoff">
         <p>
-            Spinoff this clone from its base.
+            <%= l 'Spinoff this clone from its base.' %>
         </p>
     </div>
 </div>
 <div ng-show="confirm_spinoff" class="alert alert-warning">
-            <p><%=l 'Are you sure you want to spinoff from the base ? ' %></p>
+            <p><%=l 'Are you sure you want to spinoff from the base ?' %></p>
             <button type="button" class="btn btn-secondary" data-dismiss="modal" ng-click="confirm_spinoff=false"><%=l 'No' %></button>
             <button type="button" class="btn btn-primary"
                 ng-click="confirm_spinoff=false;request('spinoff',{ 'id_domain': showmachine.id })" ><%=l 'Yes' %></button>

--- a/templates/main/vm_status.html
+++ b/templates/main/vm_status.html
@@ -1,4 +1,4 @@
-<div class="header"> <%=l 'Status'%>:
+<div class="header"> <%=l 'Status' %>:
     <span ng-show="{{showmachine.is_paused && showmachine.is_active}}"
                          class="label label-warning">
                           <%=l 'Paused' %>
@@ -13,6 +13,6 @@
     <hr>
     <div ng-show="{{showmachine.is_locked}}">
                         <%=l 'Machine locked by' %>
-                        <a href="/request/{{showmachine.is_locked}}.html"><%=l ' process' %></a>
+                        <a href="/request/{{showmachine.is_locked}}.html"> <%=l 'process' %></a>
     </div>
 </div>

--- a/templates/ng-templates/booking/calendar.html.ep
+++ b/templates/ng-templates/booking/calendar.html.ep
@@ -8,7 +8,7 @@
     <div class="page-header">
         <div class="card">
             <div class="card-header">
-                <h2>Bookings</h2>
+                <h2><%=l 'Bookings' %></h2>
             </div>
         </div>
     </div>

--- a/templates/ng-templates/error.html.ep
+++ b/templates/ng-templates/error.html.ep
@@ -7,7 +7,7 @@
 
         <div class="jumbotron">
 
-            <h1>Error</h1>
+            <h1><%=l 'Error' %></h1>
 
             <div class="alert alert-warning">
 

--- a/templates/ng-templates/list_next_bookings_today.html.ep
+++ b/templates/ng-templates/list_next_bookings_today.html.ep
@@ -1,11 +1,11 @@
 <div class="card-body" ng-show="1">
 <div ng-show="bookings_today.length" class="col-sm-12 d-inline-block mb-2">
 <div class="card-header">
-<h4>Today Schedule</h4>
+<h4><%=l 'Today Schedule' %></h4>
 
     <p>
-    This server has reservations for today. Machines from users out of
-    the booking list will be shut down.
+    <%=l 'This server has reservations for today. Machines from users out of
+    the booking list will be shutdown.' %>
     </p>
 
     <table border="1" bordercolor="darkgray" cellpadding="5">

--- a/templates/ng-templates/machines_notif.html.ep
+++ b/templates/ng-templates/machines_notif.html.ep
@@ -1,16 +1,16 @@
 <div class="panel panel-default">
 <div class="panel-heading">
-  <h4 class="panel-title">Machines Notifications<a style="float: right;" data-toggle="collapse" href="#collapse1"><i class="fa fa-angle-double-up" aria-hidden="true"></i></a> </h4>
+  <h4 class="panel-title"><%=l 'Machines Notifications' %><a style="float: right;" data-toggle="collapse" href="#collapse1"><i class="fa fa-angle-double-up" aria-hidden="true"></i></a> </h4>
 </div><!-- from panel-heading -->
 <div id="collapse1" class="panel-collapse collapse in">
 
   	<ul class="list-group">
 	    <li class="list-group-item" ng-repeat="request in res">
 	        <div ng-show="request.error != ''">
-	            <strong>Machine {{request.name}} -> {{request.command}}: </strong>Error: {{request.error}} {{request.date_changed | date:'MM/dd/yyyy @ h:mma'}}
+	            <strong><%=l 'Machine' %> {{request.name}} -> {{request.command}}: </strong><%=l 'Error' %>: {{request.error}} {{request.date_changed | date:'MM/dd/yyyy @ h:mma'}}
 	        </div>
 	        <div ng-show="request.error == ''">
-	            <strong>Machine {{request.name}} -> {{request.command}}: </strong>Status: {{request.status}} {{request.date_changed | date:'MM/dd/yyyy @ h:mma'}}
+	            <strong><%=l 'Machine' %> {{request.name}} -> {{request.command}}: </strong><%=l 'Status' %>: {{request.status}} {{request.date_changed | date:'MM/dd/yyyy @ h:mma'}}
 	        </div>
 	    </li>
 	</ul>

--- a/templates/ng-templates/new_group.html.ep
+++ b/templates/ng-templates/new_group.html.ep
@@ -31,6 +31,6 @@
         % }
     </form>
     <div ng-show="<%= $groupname && !scalar(@$error) %>">
-        Group name <a href="/admin/group/<%= $groupname %>"><%= $groupname %></a> added.
+        <%=l 'Group name' %> <a href="/admin/group/<%= $groupname %>"><%= $groupname %></a> <%=l 'added' %>.
     </div>
 </div>

--- a/templates/ng-templates/new_machine_other.html.ep
+++ b/templates/ng-templates/new_machine_other.html.ep
@@ -60,7 +60,7 @@
                     </div>
                     <div ng-show="new_machine_other_form.copy_name.$error.pattern"
                         class="form-group row alert alert-danger" role="alert">
-                        <strong><%=l 'Error' %> : </strong> <%=l 'The machine name must contain only alphabetic, numbers, undercores and dashes.' %>
+                        <strong><%=l 'Error' %> : </strong> <%=l 'The machine name is only allowed to consist of alphabetic characters, numbers, dashes and points.' %>
                     </div>
 
 

--- a/templates/ng-templates/new_machine_other.html.ep
+++ b/templates/ng-templates/new_machine_other.html.ep
@@ -39,7 +39,7 @@
                     </div>
                     <div class="form-group row">
                         <div class="col-xl-2">
-                            <label class="col-xl-12 text-muted" for="copy_ram">RAM (Gb):</label>
+                            <label class="col-xl-12 text-muted" for="copy_ram"><%=l 'RAM (Gb)' %>:</label>
                         </div>
                         <div class="col-xl-2">
                             <input class="form-control" ng-model="ramsize" type="text"
@@ -50,9 +50,9 @@
                     </div>
                     <div class="form-group row alert alert-warning"
                         ng-hide="src_machine.is_base || !src_machine">
-                        The source machine is not a base. It must be
+                        <%=l 'The source machine is not a base. It must be
                         prepared before it can be copied. This
-                        process may take some minutes.
+                        process may take some minutes.' %>
                     </div>
                     <div ng-show="name_duplicated" class="form-group row alert alert-danger"
                             role="alert">

--- a/templates/ng-templates/new_machine_template.html.ep
+++ b/templates/ng-templates/new_machine_template.html.ep
@@ -46,7 +46,7 @@
                         <div ng-show="id_iso.name && ( !id_iso.device && id_iso.url )
                                 && !id_iso.downloading
                                 && (iso_file == '<NONE>' || !iso_file) ">
-                            <font color="#500000"><%=l 'This ISO image has not been already downloaded. This may take many minutes, even hours until the file is fetched from Internet.' %></font>
+                            <font color="#500000"><%=l 'This ISO image has not been downloaded yet. It may take some minutes, even hours until the file is fetched from the Internet.' %></font>
                             <input type="checkbox" name="_download_"
                                 ng-click="iso_download(id_iso)"
                             /> <%=l "Download now" %>
@@ -247,7 +247,7 @@
                         <strong><%=l 'Error' %></strong> <%=l 'A machine with that name already exists.' %>
                 </div>
                 <div ng-show="new_machineForm.name.$error.pattern" class="alert alert-warning" role="alert">
-                        <strong><%=l 'Error' %></strong> <%=l 'The machine name must contain only alphabetic, numbers, undercores and dashes.' %>
+                        <strong><%=l 'Error' %></strong> <%=l 'The machine name is only allowed to consist of alphabetic characters, numbers, dashes and points.' %>
                 </div>
                 <div ng-show="id_iso && !id_iso.id" class="alert alert-warning"
                     role="alert">

--- a/templates/ng-templates/new_machine_template.html.ep
+++ b/templates/ng-templates/new_machine_template.html.ep
@@ -1,7 +1,7 @@
 <div class="tab-pane fade show active" id="fromtemplate" role="tabpanel">
     <div class="card-body">
         <div ng-show="!backends">
-            Loading ... <i class="fas fa-sync-alt fa-spin"></i>
+            <%=l 'Loading ...' %> <i class="fas fa-sync-alt fa-spin"></i>
         </div>
         <form name="new_machineForm" role="form" method="post"
                 class="needs-validation"
@@ -9,7 +9,7 @@
                 ng-show="backends">
             <div class="form-group row">
                 <label for="backend" class="col-xl-3 col-form-label"><%=l 'Backend' %> <a
-                  title="Choose the virtualization type of the Virtual Machine." ng-show="backends.length > 1"><i class="fa fa-info-circle"></i></a></label>
+                  title="<%=l 'Choose the virtualization type of the Virtual Machine.' %>" ng-show="backends.length > 1"><i class="fa fa-info-circle"></i></a></label>
                 <div class="col-lg-9">
                     <label for="backend" class="col-xl-3 col-form-label" ng-show="backends.length === 1">{{backends[0]}}</label>
                     <select class= "form-control" ng-show="backends.length > 1"
@@ -49,13 +49,13 @@
                             <font color="#500000"><%=l 'This ISO image has not been downloaded yet. It may take some minutes, even hours until the file is fetched from the Internet.' %></font>
                             <input type="checkbox" name="_download_"
                                 ng-click="iso_download(id_iso)"
-                            /> <%=l "Download now" %>
+                            /> <%=l 'Download now' %>
                         </div>
                     </div>
                 </div>
                 <div class="from-group row" ng-show="id_iso.name && id_iso.has_cd">
                         <label for="iso_file" class="col-xl-3 col-form-label"><%=l 'Select ISO' %> <a
-                          title="Select the .iso file the machine will utilize when installing the OS." href="http://ravada.readthedocs.io/en/latest/docs/new_iso_image.html"><i class="fa fa-info-circle"></i></a>
+                          title="<%=l 'Select the .iso file the machine will utilize when installing the OS.' %>" href="http://ravada.readthedocs.io/en/latest/docs/new_iso_image.html"><i class="fa fa-info-circle"></i></a>
                             <i class="badge badge-warning" ng-click="refresh_storage()"><i class="fa fa-sync-alt" aria-hidden="true"></i></i>
                             </label>
                         <div class="col-lg-9"  ng-init="iso_file = '<NONE>'" >
@@ -68,7 +68,7 @@
                                    ng-hide="refresh_working || !isos ||id_iso.downloading"
                                    uib-typeahead="item for item in getVisualizableObjects($viewValue, isos)"
                                    typeahead-min-length="0"/>
-                        <span class="info" ng-show="id_iso.downloading">This ISO is being downloaded. The virtual machine will be created after.</span>
+                        <span class="info" ng-show="id_iso.downloading"><%=l 'This ISO is being downloaded. The virtual machine will be created after.' %></span>
                         </div>
                 </div>
             </div>
@@ -145,16 +145,16 @@
                 <div class="col-lg-1">
                    <a ng-show="!swap.enabled"
                       ng-click="swap.enabled=true"
-                      align="right"><span class="badge badge-primary ml-2">Enable</span></a>
+                      align="right"><span class="badge badge-primary ml-2"><%=l 'Enable' %></span></a>
                   <a ng-show="swap.enabled"
                       ng-click="swap.enabled=false"
-                      align="right"><span class="badge badge-primary ml-2">Disable</span></a>
+                      align="right"><span class="badge badge-primary ml-2"><%=l 'Disable' %></span></a>
                </div>
                <div class="col-lg-6">
                   <span ng-show="swap.enabled && swap.value < id_iso.min_swap_size">
                     <font color="orange"><%=l 'The Minimum Swap Disk Size needed for this ISO is' %> {{id_iso.min_swap_size}}GB.</font>
                   </span>
-                    <span>Content will be cleaned on restore and shutdown</span>
+                    <span><%=l 'Content will be cleaned on restore and shutdown' %></span>
                </div>
             </div>
             <div class="form-group row" ng-show="backend == 'KVM' || backend=='Void'">
@@ -172,13 +172,13 @@
                 <div class="col-lg-1">
                    <a ng-show="!data.enabled"
                       ng-click="data.enabled=true"
-                      align="right"><span class="badge badge-primary ml-2">Enable</span></a>
+                      align="right"><span class="badge badge-primary ml-2"><%=l 'Enable' %></span></a>
                   <a ng-show="data.enabled"
                       ng-click="data.enabled=false"
-                      align="right"><span class="badge badge-primary ml-2">Disable</span></a>
+                      align="right"><span class="badge badge-primary ml-2"><%=l 'Disable' %></span></a>
                </div>
                <div class="col-lg-6">
-                    <span>Content will be kept on restore</span>
+                    <span><%=l 'Content will be kept on restore' %></span>
                </div>
             </div>
 

--- a/templates/ng-templates/support_form.html.ep
+++ b/templates/ng-templates/support_form.html.ep
@@ -1,47 +1,47 @@
 <div ng-show="0" class="panel panel-primary">
     <div class="panel-heading">
-        <h2>Support Contact</h2>
-        <p>If you have any issue, you can contact the Suport crew and we will try to help you. Please, only contact Support Center if it is strictly necessary.</p>
+        <h2><%=l 'Support Contact' %></h2>
+        <p><%=l 'If you have any issue, you can contact the Suport crew and we will try to help you. Please, only contact Support Center if it is strictly necessary.' %></p>
     </div>
 
     <div class="panel-footer">
         <form name="contactForm" role="form" ng-submit="contactForm.$valid" novalidate>
             <div class="form-group">
-                <label>Name</label>
+                <label><%=l 'Name' %></label>
                 <input type="text" class="form-control" ng-model="user.name" placeholder="John Doe" required>
             </div>
             <div class="form-group">
-                <label>Email</label>
+                <label><%=l 'Email' %></label>
                 <input type="email" ng-model="user.email" class="form-control" placeholder="john.doe@example.com" required>
             </div>
             <div class="form-group">
-                <label>Phone Number</label>
+                <label><%=l 'Phone Number' %></label>
                 <input type="number" ng-model="user.phone" class="form-control" placeholder="+34666666666">
             </div>
             <div class="form-group">
-                <label>Description:</label>
+                <label><%=l 'Description' %>:</label>
                 <textarea ng-model="user.message" class="form-control" rows="5" required></textarea>
             </div>
             <div class="form-group">
-                <label>Attachment</label>
+                <label><%=l 'Attachment' %></label>
                 <input type="file" ng-model="user.attach">
             </div>
             <div class="form-group">
-                <label>Contact Method:</label>
+                <label><%=l 'Contact Method' %>:</label>
                 <div class="checkbox">
                     <label>
-                        <input type="checkbox" ng-model="user.contactPh" value="">Phone
+                        <input type="checkbox" ng-model="user.contactPh" value=""><%=l 'Phone' %>
                     </label>
 
                     <label>
-                        <input type="checkbox" ng-model="user.contactEm" value="">Email
+                        <input type="checkbox" ng-model="user.contactEm" value=""><%=l 'Email' %>
                     </label>
                 </div>
             </div>
             <div ng-show="showErr" class="alert alert-danger">
-                <strong>Error</strong>  Fill required camps with valid data.
+                <strong><%=l 'Error' %></strong>  <%=l 'Fill required camps with valid data' %>.
             </div>
-            <button type="submit" ng-click="isOkey()" class="btn btn-default">Submit</button>
+            <button type="submit" ng-click="isOkey()" class="btn btn-default"><%=l 'Submit' %></button>
         </form>
 
     </div>

--- a/templates/ng-templates/user_machines.html.ep
+++ b/templates/ng-templates/user_machines.html.ep
@@ -7,7 +7,7 @@
         <div class="card text-white bg-success machine">
 
         <div class="card-header">
-            <h3 class="card-title">{{machine.name}} <i ng-hide="{{machine.is_public}}">( not public )</i></h3><br>
+            <h3 class="card-title">{{machine.name}} <i ng-hide="{{machine.is_public}}">( <%=l 'not public' %> )</i></h3><br>
             <img id="screensh" ng-src="/img/screenshots/{{machine.id}}.png">
         </div>
         <div class="card-body machine-card">

--- a/templates/ng-templates/user_machines.html.ep
+++ b/templates/ng-templates/user_machines.html.ep
@@ -1,6 +1,6 @@
 <div class="card-body">
     <div ng-show="pingbe_fail" class="alert alert-danger" ng-cloak>
-        <strong><%=l 'Error!' %></strong><%=l 'Backend no available!' %>
+        <strong><%=l 'Error!' %></strong><%=l 'Backend not available!' %>
       </div>
     <div ng-repeat="machine in list_bases">
         <div class="col-md-4">

--- a/templates/ng-templates/user_machines_anonymous.html.ep
+++ b/templates/ng-templates/user_machines_anonymous.html.ep
@@ -3,14 +3,14 @@
     <div class="card card-success machine">
 
     <div class="card-header">
-        <h2 class="card-title"><b>{{machine.name}}</b> (<i>volatile</i>)</h2>
-        <i>Will be destroyed on shutdown</i>
+        <h2 class="card-title"><b>{{machine.name}}</b> (<i><%=l 'volatile' %></i>)</h2>
+        <i><%=l 'Will be destroyed on shutdown' %></i>
 
         <h3>{{machine.description}}</h3>
         <img id="screensh" src="/img/screenshots/{{machine.id}}.png">
     </div>
     <div class="card-body machine-card">
-        <a type="button"  class="btn btn-success" href="/anonymous/{{machine.id}}.html"><strong>&nbsp;<i class="fa fa-play" aria-hidden="true"></i>&nbsp;Start</strong></a>
+        <a type="button"  class="btn btn-success" href="/anonymous/{{machine.id}}.html"><strong>&nbsp;<i class="fa fa-play" aria-hidden="true"></i>&nbsp;<%=l 'Start' %></strong></a>
     </div>
     </div>
     </div>


### PR DESCRIPTION
* Fixed:
In https://github.com/UPC/ravada/pull/412 msgid were updated, but strings in code were not.
For example: 
en.po — msgid "The machine name is only allowed to consist of alphabetic characters, numbers, dashes and points."
templates/ng-templates/new_machine_template.html.ep —
<%=l 'The machine name must contain only alphabetic, numbers, undercores and dashes.' %>

* Remove hardcoded strings
* All buttons are capitalized
* Added new entries to English file (en.po)

