### PR TITLE
Consistency naming for Hybernate to Hibernate in translations

### DIFF
--- a/lib/Ravada/I18N/ar.po
+++ b/lib/Ravada/I18N/ar.po
@@ -487,7 +487,7 @@ msgstr "اغلاق ..."
 msgid "It may take a couple of minutes."
 msgstr "قد يستغرق الأمر بضع دقائق"
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/ca-valencia.po
+++ b/lib/Ravada/I18N/ca-valencia.po
@@ -505,7 +505,7 @@ msgstr "Apagant ..."
 msgid "It may take a couple of minutes."
 msgstr "Pot tardar un parell de minuts."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hibernant ..."
 
 msgid "Description"

--- a/lib/Ravada/I18N/ca.po
+++ b/lib/Ravada/I18N/ca.po
@@ -504,7 +504,7 @@ msgstr "Apagant …"
 msgid "It may take a couple of minutes."
 msgstr "Pot trigar un parell de minuts."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hivernant …"
 
 msgid "Description"

--- a/lib/Ravada/I18N/de.po
+++ b/lib/Ravada/I18N/de.po
@@ -758,7 +758,7 @@ msgstr "öffentlich"
 msgid "It is required a viewer to run the virtual machines."
 msgstr "Zum Ausführen der virtuellen Maschinen ist ein Viewer erforderlich."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Ruhezustand …"
 
 msgid "This machine has not Graphics parameters!"

--- a/lib/Ravada/I18N/en.po
+++ b/lib/Ravada/I18N/en.po
@@ -503,8 +503,8 @@ msgstr "Shutting down …"
 msgid "It may take a couple of minutes."
 msgstr "It may take a couple of minutes."
 
-msgid "Hybernating ..."
-msgstr "Hybernating …"
+msgid "Hibernating ..."
+msgstr "Hibernating …"
 
 msgid "Description"
 msgstr "Description"

--- a/lib/Ravada/I18N/es.po
+++ b/lib/Ravada/I18N/es.po
@@ -505,7 +505,7 @@ msgstr "Apagando …"
 msgid "It may take a couple of minutes."
 msgstr "Puede tardar un par de minutos."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hibernando …"
 
 msgid "Description"

--- a/lib/Ravada/I18N/eu.po
+++ b/lib/Ravada/I18N/eu.po
@@ -478,7 +478,7 @@ msgstr ""
 msgid "It may take a couple of minutes."
 msgstr ""
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/fr.po
+++ b/lib/Ravada/I18N/fr.po
@@ -514,7 +514,7 @@ msgstr "Arrêt en cours..."
 msgid "It may take a couple of minutes."
 msgstr "Cela peut prendre quelques minutes."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Mise en veille..."
 
 msgid "Description"

--- a/lib/Ravada/I18N/gl.po
+++ b/lib/Ravada/I18N/gl.po
@@ -358,7 +358,7 @@ msgstr "Renomear"
 msgid "Description"
 msgstr "Descrición"
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hibernando …"
 
 msgid "It may take a couple of minutes."

--- a/lib/Ravada/I18N/he.po
+++ b/lib/Ravada/I18N/he.po
@@ -472,7 +472,7 @@ msgstr ""
 msgid "It may take a couple of minutes."
 msgstr ""
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/id.po
+++ b/lib/Ravada/I18N/id.po
@@ -570,7 +570,7 @@ msgstr "Mematikan ..."
 msgid "It may take a couple of minutes."
 msgstr "Mungkin butuh beberapa menit."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hibernasi ..."
 
 msgid "Description"

--- a/lib/Ravada/I18N/it.po
+++ b/lib/Ravada/I18N/it.po
@@ -503,7 +503,7 @@ msgstr "Chiudere ..."
 msgid "It may take a couple of minutes."
 msgstr "Potrebbero volerci un paio di minuti."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Ibernazione ..."
 
 msgid "Description"

--- a/lib/Ravada/I18N/ja.po
+++ b/lib/Ravada/I18N/ja.po
@@ -489,7 +489,7 @@ msgstr "シャットダウン.."
 msgid "It may take a couple of minutes."
 msgstr "数分かかることがあります。"
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "冬眠中の.."
 
 msgid "Description"

--- a/lib/Ravada/I18N/ko.po
+++ b/lib/Ravada/I18N/ko.po
@@ -472,7 +472,7 @@ msgstr ""
 msgid "It may take a couple of minutes."
 msgstr ""
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/messages.pot
+++ b/lib/Ravada/I18N/messages.pot
@@ -474,7 +474,7 @@ msgstr ""
 msgid "It may take a couple of minutes."
 msgstr ""
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/nb_NO.po
+++ b/lib/Ravada/I18N/nb_NO.po
@@ -478,7 +478,7 @@ msgstr ""
 msgid "It may take a couple of minutes."
 msgstr ""
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr ""
 
 msgid "Description"

--- a/lib/Ravada/I18N/pt.po
+++ b/lib/Ravada/I18N/pt.po
@@ -838,7 +838,7 @@ msgstr "Renomear"
 msgid "Description"
 msgstr "Descrição"
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "A hibernar…"
 
 msgid "It may take a couple of minutes."

--- a/lib/Ravada/I18N/ru.po
+++ b/lib/Ravada/I18N/ru.po
@@ -494,7 +494,7 @@ msgstr "Выключение…"
 msgid "It may take a couple of minutes."
 msgstr "Это может занять пару минут."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Приостановка…"
 
 msgid "Description"

--- a/lib/Ravada/I18N/tr.po
+++ b/lib/Ravada/I18N/tr.po
@@ -500,7 +500,7 @@ msgstr "Kapanıyor…"
 msgid "It may take a couple of minutes."
 msgstr "Birkaç dakika sürebilir."
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "Hazırda bekletiliyor…"
 
 msgid "Description"

--- a/lib/Ravada/I18N/zh_CN.po
+++ b/lib/Ravada/I18N/zh_CN.po
@@ -482,7 +482,7 @@ msgstr "关机中…"
 msgid "It may take a couple of minutes."
 msgstr "这将会花费几分钟。"
 
-msgid "Hybernating ..."
+msgid "Hibernating ..."
 msgstr "休眠中…"
 
 msgid "Description"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated all the translations to leverage hibernate instead of hybernate to maintain consistency. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
Bring consistency in the documentation
<!--- If it fixes an open issue, please link to the issue here. --> 
#1811 
