### PR TITLE
Fix clone name

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -4312,8 +4312,10 @@ sub _new_clone_name($self, $base,$user) {
     my $name;
     my $alias = $base->name;
     $alias = $base->_data('alias') if $base->_data('alias');
-    if ($user->name =~ /^[a-z0-9_\-]+$/i) {
-        $name = $base->name."-".$user->name;
+    my $user_name = Encode::decode_utf8($user->name);
+    if ($user_name =~ /^[a-zA-Z0-9âêîôûáéíóúàèìòùäëïöüçñ'_\.\-€\$]+$/i) {
+        $user_name = $base->_vm->_set_ascii_name(Encode::decode_utf8($user->name));
+        $name = $base->name."-".$user_name;
         $alias .= "-".$user->name;
     } else {
         my $length = length($user->id);

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -4316,7 +4316,7 @@ sub _new_clone_name($self, $base,$user) {
     if ($user_name =~ /^[a-zA-Z0-9âêîôûáéíóúàèìòùäëïöüçñ'_\.\-€\$]+$/i) {
         $user_name = $base->_vm->_set_ascii_name(Encode::decode_utf8($user->name));
         $name = $base->name."-".$user_name;
-        $alias .= "-".$user->name;
+        $alias .= "-".Encode::decode_utf8($user->name);
     } else {
         my $length = length($user->id);
         my $n = "0" x (4-$length);

--- a/lib/Ravada/Front/Domain/KVM.pm
+++ b/lib/Ravada/Front/Domain/KVM.pm
@@ -401,7 +401,7 @@ sub _get_driver_disk($self) {
 
 sub vm_version($self) {
     my $sth = $self->_dbh->prepare(
-        "SELECT version FROM vms v, domains d"
+        "SELECT v.version FROM vms v, domains d"
         ." WHERE v.id=d.id_vm "
         ."    AND d.id=?"
     );

--- a/lib/Ravada/VM.pm
+++ b/lib/Ravada/VM.pm
@@ -407,7 +407,7 @@ sub _around_create_domain {
 
     my $config = delete $args{config};
 
-    if ($name !~ /^[a-zA-Z0-9_-]+$/) {
+    if ($name !~ /^[a-zA-Z0-9_\.\-]+$/) {
         $alias = $self->_set_alias_unique($alias or $name);
         $name = $self->_set_ascii_name($name);
         $args_create{name} = $name;
@@ -519,9 +519,9 @@ sub _around_create_domain {
 
 sub _set_ascii_name($self, $name) {
     my $length = length($name);
-    $name =~ tr/áéíóúàèìòùäëïöüçñ€$/aeiouaeiouaeioucnes/;
-    $name =~ tr/ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÇÑ€$/AEIOUAEIOUAEIOUCNES/;
-    $name =~ tr/A-Za-z0-9_\-/\-/c;
+    $name =~ tr/âêîôûáéíóúàèìòùäëïöüçñ'/aeiouaeiouaeiouaeioucn_/;
+    $name =~ tr/ÂÊÎÔÛÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÇÑ€$/AEIOUAEIOUAEIOUAEIOUCNES/;
+    $name =~ tr/A-Za-z0-9_\.\-/\-/c;
     $name =~ s/^\-*//;
     $name =~ s/\-*$//;
     $name =~ s/\-\-+/\-/g;

--- a/lib/Ravada/VM.pm
+++ b/lib/Ravada/VM.pm
@@ -407,7 +407,7 @@ sub _around_create_domain {
 
     my $config = delete $args{config};
 
-    if ($name !~ /^[a-zA-Z0-9_\.\-]+$/) {
+    if ($name !~ /^[a-zA-Z0-9_\-]+$/) {
         $alias = $self->_set_alias_unique($alias or $name);
         $name = $self->_set_ascii_name($name);
         $args_create{name} = $name;
@@ -519,7 +519,7 @@ sub _around_create_domain {
 
 sub _set_ascii_name($self, $name) {
     my $length = length($name);
-    $name =~ tr/âêîôûáéíóúàèìòùäëïöüçñ'/aeiouaeiouaeiouaeioucn_/;
+    $name =~ tr/.âêîôûáéíóúàèìòùäëïöüçñ'/-aeiouaeiouaeiouaeioucn_/;
     $name =~ tr/ÂÊÎÔÛÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÇÑ€$/AEIOUAEIOUAEIOUAEIOUCNES/;
     $name =~ tr/A-Za-z0-9_\.\-/\-/c;
     $name =~ s/^\-*//;

--- a/lib/Ravada/VM/Void.pm
+++ b/lib/Ravada/VM/Void.pm
@@ -242,7 +242,7 @@ sub _is_a_domain($self, $file) {
     chomp $file;
 
     return if $file !~ /\.yml$/;
-    $file =~ s/\.\w+//;
+    $file =~ s/\.\w+$//;
     $file =~ s/(.*)\.qcow.*$/$1/;
     return if $file !~ /\w/;
 

--- a/script/rvd_front
+++ b/script/rvd_front
@@ -2553,7 +2553,7 @@ sub new_machine {
         push @error,("Name is mandatory")   if !$c->param('name');
         push @error,("Invalid name '".$c->param('name')."'"
                 .".It can only contain alphabetic, numbers, undercores and dashes.")
-            if $c->param('name') && $c->param('name') !~ /^[а-яА-Яa-zA-Z0-9àèìòùáéíóúäëïöüçñ€_\$\-]+$/i;
+            if $c->param('name') && $c->param('name') !~ /^[а-яА-Яa-zA-Z0-9àèìòùáéíóúäëïöüçñ€_\$\-\.]+$/i;
         if (!@error) {
             req_new_domain($c);
             $c->redirect_to("/admin/machines");

--- a/t/lib/Test/Ravada.pm
+++ b/t/lib/Test/Ravada.pm
@@ -657,9 +657,18 @@ sub remove_old_domains_req($wait=1, $run_request=0) {
 sub remove_domain(@bases) {
 
     for my $base (@bases) {
+        confess if !defined $base;
         for my $clone ($base->clones) {
             my $d_clone = Ravada::Domain->open($clone->{id});
-            remove_domain($d_clone);
+            if ( $d_clone ) {
+                remove_domain($d_clone);
+            } else {
+                Ravada::Request->remove_domain(
+                    uid => user_admin->id
+                    ,name => $clone->{name}
+                );
+                wait_request();
+            }
         }
         $base->remove(user_admin);
     }

--- a/t/user/utf.t
+++ b/t/user/utf.t
@@ -36,9 +36,10 @@ sub test_user_cyrillic($vm) {
     my ($clonef) = $base->clones();
 
     ok(utf8::valid($clonef->{name}));
-    is($clonef->{name},$base->name."-000".$user->id) or exit;
-
     my $base_name = $base->name;
+    my $user_id = $user->id;
+    like($clonef->{name},qr/^${base_name}-0+${user_id}$/) or exit;
+
     like($clonef->{alias},qr/$base_name-$name/) or exit;
 
     _test_utf8($user);
@@ -66,6 +67,101 @@ sub test_user_cyrillic($vm) {
 
     remove_domain($base);
 }
+
+sub test_user_name_surname($vm) {
+    my $base = create_domain_v2(vm => $vm);
+    $base->is_public(1);
+    $base->prepare_base(user_admin);
+    diag($base->name);
+
+    for my $sep (qw (. _ -)) {
+        my $name = new_domain_name()."${sep}pep${sep}bartroli";
+        my $user = create_user($name, $$);
+        ok(utf8::valid($user->name));
+
+        my $req = Ravada::Request->clone(
+            uid => $user->id
+            ,id_domain => $base->id
+        );
+        wait_request();
+        is($req->error,'');
+        my ($clonef) = grep { $_->{id_owner} == $user->id } $base->clones();
+        ok($clonef,"Expecting a clone owned by ".$user->id) or next;
+
+        ok(utf8::valid($clonef->{name}));
+        is($clonef->{name},$base->name."-".$user->name) or exit;
+
+        my $base_name = $base->name;
+        is($clonef->{name},"$base_name-$name") or exit;
+        is($clonef->{alias},$clonef->{name});
+
+        _test_utf8($user);
+        _test_messages_utf8($user);
+    }
+
+    remove_domain($base);
+}
+
+sub test_user_name_europe($vm) {
+    my $base = create_domain_v2(vm => $vm);
+    $base->is_public(1);
+    $base->prepare_base(user_admin);
+    diag($base->name);
+
+    my %replace = (
+        'á' => 'a'
+        ,'è' => 'e'
+        ,'ï' => 'i'
+        ,'ò' => 'o'
+        ,'ó' => 'o'
+        ,'ü' => 'u'
+        ,'ç' => 'c'
+        ,'À' => 'A'
+        ,'È' => 'E'
+        ,'Ï' => 'I'
+        ,'Ö' => 'O'
+        ,'Ú' => 'U'
+        ,'â' => 'a'
+        ,'Ê' => 'E'
+        ,"'" => '_'
+        ,'€' => 'E'
+        ,'$' => 'S'
+
+    );
+    for my $letter (sort keys %replace) {
+        my $prefix = new_domain_name();
+        my $name = "$prefix.$letter.pep${letter}";
+        my $expected =$prefix.".".$replace{$letter}.".pep".$replace{$letter};
+        my $user = create_user($name, $$);
+        ok(utf8::valid($user->name));
+
+        my $req = Ravada::Request->clone(
+            uid => $user->id
+            ,id_domain => $base->id
+        );
+        wait_request();
+        is($req->error,'');
+        my ($clonef) = grep { $_->{id_owner} == $user->id } $base->clones();
+        ok($clonef,"Expecting a clone owned by ".$user->id) or next;
+
+        ok(utf8::valid($clonef->{name}));
+
+        my $base_name = $base->name;
+        is($clonef->{name},"$base_name-$expected") or exit;
+        is($clonef->{alias},"$base_name-$name");
+        isnt($clonef->{alias},$clonef->{name});
+
+        _test_utf8($user);
+        _test_messages_utf8($user);
+
+        my $clone = Ravada::Domain->open($clonef->{id});
+        ok($clone,"Expecting domain $clonef->{id} $clonef->{name} $clonef->{alias}") or exit;
+    }
+
+    remove_domain($base);
+}
+
+
 
 sub _test_utf8($user) {
     _test_messages_utf8($user);
@@ -173,6 +269,8 @@ for my $vm_name (vm_names()) {
 
         diag($msg)      if !$vm;
         skip $msg,10    if !$vm;
+        test_user_name_surname($vm);
+        test_user_name_europe($vm);
         test_renamed_conflict($vm);
         test_domain_catalan($vm);
         test_user_cyrillic($vm);


### PR DESCRIPTION
Clones names had de uid instead the username when user had dots. Reported by Pep Bartrolí from UPC.
Also we improved the transform into ascii when possible.
