### PR TITLE
properly check and remove machines with UTF names

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -3125,8 +3125,8 @@ sub remove_domain {
 
     lock_hash(%arg);
 
-    my $sth = $CONNECTOR->dbh->prepare("SELECT id,vm FROM domains WHERE name = ?");
-    $sth->execute($name);
+    my $sth = $CONNECTOR->dbh->prepare("SELECT id,vm FROM domains WHERE name = ? or alias=?");
+    $sth->execute($name,$name);
 
     my ($id,$vm_type)= $sth->fetchrow;
     confess "Error: Unknown domain $name"   if !$id;
@@ -4339,7 +4339,8 @@ sub _new_clone_name($self, $base,$user) {
         $alias .= "-".Encode::decode_utf8($user->name);
     } else {
         my $length = length($user->id);
-        my $n = "0" x (4-$length);
+        my $n =  '';
+        $n = "0" x (4-$length) if $length < 4;
         $name = $base->name."-".$n.$user->id;
         $alias .= "-".Encode::decode_utf8($user->name);
     }

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -3125,8 +3125,8 @@ sub remove_domain {
 
     lock_hash(%arg);
 
-    my $sth = $CONNECTOR->dbh->prepare("SELECT id,vm FROM domains WHERE name = ? or alias=?");
-    $sth->execute($name,$name);
+    my $sth = $CONNECTOR->dbh->prepare("SELECT id,vm FROM domains WHERE name = ?");
+    $sth->execute($name);
 
     my ($id,$vm_type)= $sth->fetchrow;
     confess "Error: Unknown domain $name"   if !$id;

--- a/lib/Ravada/Request.pm
+++ b/lib/Ravada/Request.pm
@@ -34,7 +34,7 @@ my $COUNT = 0;
 our %FIELD = map { $_ => 1 } qw(error output);
 our %FIELD_RO = map { $_ => 1 } qw(id name);
 
-our $args_manage = { name => 1 , uid => 1 };
+our $args_manage = { name => 1 , uid => 1, after_request => 2 };
 our $args_prepare = { id_domain => 1 , uid => 1, with_cd => 2 };
 our $args_remove_base = { id_domain => 1 , uid => 1 };
 our $args_manage_iptables = {uid => 1, id_domain => 1, remote_ip => 1};

--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -749,11 +749,14 @@ sub list_domains {
     my @list;
     while ( my ($id) = $sth->fetchrow) {
         my $domain;
-        if ($read_only) {
-            $domain = Ravada::Front::Domain->open( $id );
-        } else {
-            $domain = Ravada::Domain->open( id => $id, vm => $self);
-        }
+        eval{
+            if ($read_only) {
+                $domain = Ravada::Front::Domain->open( $id );
+            } else {
+                $domain = Ravada::Domain->open( id => $id, vm => $self);
+            }
+        };
+        die $@ if $@ && $@ !~ /Unkown domain/i;
         push @list,($domain) if $domain;
     }
     return @list;

--- a/lib/Ravada/Volume.pm
+++ b/lib/Ravada/Volume.pm
@@ -211,7 +211,7 @@ sub base_extension($self) {
 
 sub set_info($self, $name, $value) {
     $self->{info}->{$name} = $value;
-    $self->_cache_volume_info() if $self->domain();
+    $self->_cache_volume_info() if $self->domain() && $self->domain()->is_known();
 }
 
 sub delete($self) {
@@ -272,6 +272,7 @@ sub _cache_volume_info($self) {
             ,encode_json(\%info)
         );
         };
+        return if $@ && $@ =~ /foreign key constraint fails/i;
         confess "$name / $n_order \n".$@ if $@;
         return;
     }

--- a/t/mojo/50_utf8.t
+++ b/t/mojo/50_utf8.t
@@ -175,6 +175,7 @@ sub test_clone_utf8_user($t, $vm_name, $name, $utf8_base=0) {
 
     _test_discover($vm_name);
 
+    mojo_login($t, $user_name, $$);
     $t->post_ok("/request/prepare_base/", json => {
             id_domain => $domain->id
         });

--- a/t/mojo/50_utf8.t
+++ b/t/mojo/50_utf8.t
@@ -99,13 +99,11 @@ sub test_rename_ascii($t, $vm_name, $base_name) {
     is($domain2->_data('name'), $new_name);
     is($domain2->_data('alias'), $new_name);
 
-    _test_discover($vm_name);
-
     Ravada::Request->remove_domain(
         uid => user_admin->id
         ,name => $domain2->name
     );
-
+    _test_discover($vm_name);
 }
 
 sub test_clone_utf8_domain($t, $vm_name, $base_name) {
@@ -116,6 +114,8 @@ sub _new_machine($vm_name, $user, $base_name) {
 
     my $iso_name = 'Alpine%64 bits';
     my $id_iso = search_id_iso($iso_name);
+
+    _test_discover($vm_name);
 
     $t->post_ok("/new_machine.html",
         form => {
@@ -135,6 +135,7 @@ sub _new_machine($vm_name, $user, $base_name) {
 
     my ($created) = rvd_front->search_domain($base_name);
     ok($created, "Expecting $base_name created") or exit;
+    _test_discover($vm_name);
     return $created;
 }
 


### PR DESCRIPTION
Test removal that failed sometimes for bases because two requests run at the same time. Also lists may fail when machine was just removed.
