### PR TITLE
fix: set original non-translated value

### DIFF
--- a/templates/main/manage_machine_edit_features.html.ep
+++ b/templates/main/manage_machine_edit_features.html.ep
@@ -12,15 +12,15 @@
                     && ( value != '1' && value != '0' )">
         <%=l 'state' %>
             <select ng-model="item[feat].state" >
-            <option><%=l 'on' %></option>
-            <option><%=l 'off' %></option>
+            <option value="on"><%=l 'on' %></option>
+            <option value="off"><%=l 'off' %></option>
             </select>
         </span>
         <span ng-show="feat == 'kvm' && value != '1' && value != '0'">
             <%=l 'hidden' %>
             <select ng-model="item[feat].hidden.state">
-                <option><%=l 'on' %></option>
-                <option><%=l 'off' %></option>
+                <option value="on"><%=l 'on' %></option>
+                <option value="off"><%=l 'off' %></option>
             </select>
         </span>
         <small>


### PR DESCRIPTION
Features update crashed because the translated values where sent