### PR TITLE
fix: correctly change topology when no previous model

### DIFF
--- a/lib/Ravada/Domain/KVM.pm
+++ b/lib/Ravada/Domain/KVM.pm
@@ -3348,7 +3348,11 @@ sub _change_xml($xml, $name, $data) {
             if ($node->textContent ne $text) {
                 my ($n_text) = $node->findnodes("text()");
                 eval {
-                    $n_text->setData($text);
+                    if (!$n_text) {
+                        $node->appendText($text);
+                    } else {
+                        $n_text->setData($text);
+                    }
                 };
                 confess $@."\n".Dumper($node->toString,$name,$data)
                 if $@;

--- a/t/request/30_hardware.t
+++ b/t/request/30_hardware.t
@@ -1283,6 +1283,9 @@ sub _test_cpu_topology_old_cpu($domain) {
     $cpu->removeAttribute('match');
 
     my ($model) = $cpu->findnodes('model');
+    $cpu->removeChild($model);
+
+    $domain->reload_config($doc);
 
     my $model_exp = 'kvm64';
 


### PR DESCRIPTION
Properly test the empty cpu model thanks to Susana Aguilar