### PR TITLE
Fix: update isos when no internet available

### DIFF
--- a/etc/rvd_front.conf.example
+++ b/etc/rvd_front.conf.example
@@ -31,7 +31,7 @@
   ,session_timeout_admin2 => 60*60
 
   ,auto_view => 0
-  ,fallback => 0
+  ,fallback => 1
   ,log => {
       log => 0
       ,file => '/var/log/ravada/rvd_front.log'

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -815,6 +815,9 @@ sub _update_isos {
           ,has_cd => 0
         }
     );
+    $self->_update_table($table, $field, \%data);
+    $self->_update_table_isos_url(\%data);
+
     $self->_scheduled_fedora_releases(\%data) if $0 !~ /\.t$/;
     $self->_update_table($table, $field, \%data);
 
@@ -1407,7 +1410,6 @@ sub _update_data {
     my $self = shift;
 
     $self->_remove_old_isos();
-    $self->_update_isos();
 
     $self->_install_grants();
     $self->_remove_old_indexes();

--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -1469,7 +1469,13 @@ sub _ua_get($self, $url) {
         sleep 1+$try;
     }
     confess "Error getting '$url'" if !$res;
-    return unless $res->code == 200 || $res->code == 301;
+
+    if (!defined $res->code && ($res->code == 200 || $res->code == 301)) {
+        my $msg = "Error getting '$url'";
+        $msg .= " ".$res->code if defined $res->code;
+        $msg .= " ".$res->message if defined $res->message;
+        die "$msg\n";
+    }
 
     $self->_cache_store($url,$res->body);
     return $res->dom;

--- a/lib/Ravada/VM/KVM.pm
+++ b/lib/Ravada/VM/KVM.pm
@@ -1470,7 +1470,7 @@ sub _ua_get($self, $url) {
     }
     confess "Error getting '$url'" if !$res;
 
-    if (!defined $res->code && ($res->code == 200 || $res->code == 301)) {
+    if (!defined $res->code || !($res->code == 200 || $res->code == 301)) {
         my $msg = "Error getting '$url'";
         $msg .= " ".$res->code if defined $res->code;
         $msg .= " ".$res->message if defined $res->message;

--- a/t/lib/Test/Ravada.pm
+++ b/t/lib/Test/Ravada.pm
@@ -468,6 +468,7 @@ sub rvd_back($config=undef, $init=1, $sqlite=1) {
                 , pid_name => $pid_name
     );
     $rvd->_install();
+    $rvd->_update_isos();
     $CONNECTOR = $rvd->connector if !$sqlite;
 
     user_admin();


### PR DESCRIPTION
Properly show an error message when there is no internet available. Also keep installing downloading process in the background for a faster startup.