### PR TITLE
refactor: do not load LDAP when no configured

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -2829,7 +2829,9 @@ sub display_ip($self=undef, $new_ip=undef) {
         if (!length $new_ip) {
             delete $CONFIG->{display_ip};
         } else {
+            unlock_hash(%$CONFIG);
             $CONFIG->{display_ip} = $new_ip;
+            lock_hash(%$CONFIG);
         }
     }
     my $ip;
@@ -2848,7 +2850,9 @@ sub nat_ip($self=undef, $new_ip=undef) {
         if (!length $new_ip) {
             delete $CONFIG->{nat_ip};
         } else {
+            unlock_hash(%$CONFIG);
             $CONFIG->{nat_ip} = $new_ip;
+            lock_hash(%$CONFIG);
         }
     }
 

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -2878,6 +2878,8 @@ sub _init_config {
 #    $CONNECTOR = ( $connector or _connect_dbh());
 
     _init_config_vm();
+
+    lock_hash(%$CONFIG);
 }
 
 sub _init_config_vm {

--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -2826,13 +2826,13 @@ Returns the default display IP read from the config file
 
 sub display_ip($self=undef, $new_ip=undef) {
     if (defined $new_ip) {
+        unlock_hash(%$CONFIG);
         if (!length $new_ip) {
             delete $CONFIG->{display_ip};
         } else {
-            unlock_hash(%$CONFIG);
             $CONFIG->{display_ip} = $new_ip;
-            lock_hash(%$CONFIG);
         }
+        lock_hash(%$CONFIG);
     }
     my $ip;
     $ip = $CONFIG->{display_ip} if exists $CONFIG->{display_ip};
@@ -2847,13 +2847,13 @@ Returns the IP for NATed environments
 
 sub nat_ip($self=undef, $new_ip=undef) {
     if (defined $new_ip) {
+        unlock_hash(%$CONFIG);
         if (!length $new_ip) {
             delete $CONFIG->{nat_ip};
         } else {
-            unlock_hash(%$CONFIG);
             $CONFIG->{nat_ip} = $new_ip;
-            lock_hash(%$CONFIG);
         }
+        lock_hash(%$CONFIG);
     }
 
     return $CONFIG->{nat_ip} if exists $CONFIG->{nat_ip};

--- a/lib/Ravada/Auth/LDAP.pm
+++ b/lib/Ravada/Auth/LDAP.pm
@@ -428,6 +428,8 @@ sub remove_group {
 sub search_group {
     my %args = @_;
 
+    return if !exists $$CONFIG->{ldap} || !$$CONFIG->{ldap};
+
     my $name = delete $args{name} or confess "Error: missing name";
     my $base = ( delete $args{base} or $$CONFIG->{ldap}->{groups_base} or "ou=groups,"._dc_base() );
     my $ldap = ( delete $args{ldap} or _init_ldap_admin());

--- a/lib/Ravada/Auth/LDAP.pm
+++ b/lib/Ravada/Auth/LDAP.pm
@@ -280,6 +280,7 @@ sub search_user {
     } else {
         $args{name} = $_[0];
     }
+    die "Error: LDAP not configured" if !exists $$CONFIG->{ldap};
 
     my $username = delete $args{name} or confess "Missing user name";
     my $retry = (delete $args{retry} or 0);

--- a/lib/Ravada/Auth/SSO.pm
+++ b/lib/Ravada/Auth/SSO.pm
@@ -115,7 +115,7 @@ sub is_external { }
 
 sub init {
     state $warn = 0;
-    if ( $$CONFIG->{sso} ) {
+    if (exists $$CONFIG->{sso} && $$CONFIG->{sso} ) {
         for my $field (qw(url service cookie)) {
             if ( !exists $$CONFIG->{sso}->{$field} ) {
                 $ERR = "Error: Missing sso / $field in config file\n";

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -1496,7 +1496,6 @@ sub feature($self,$name=undef) {
         }
         return $feature;
     }
-    lock_hash(%$Ravada::CONFIG);
     return 1 if exists $Ravada::CONFIG->{$name} && $Ravada::CONFIG->{$name};
     return 0;
 }

--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -1496,6 +1496,7 @@ sub feature($self,$name=undef) {
         }
         return $feature;
     }
+    lock_hash(%$Ravada::CONFIG);
     return 1 if exists $Ravada::CONFIG->{$name} && $Ravada::CONFIG->{$name};
     return 0;
 }

--- a/script/rvd_back
+++ b/script/rvd_back
@@ -224,7 +224,7 @@ my $RVD_BACK;
 #
 
 sub _do_start_logging {
-    $LOG_FILENAME = $Ravada::CONFIG->{"log"} if (! $LOG_FILENAME);
+    $LOG_FILENAME = $Ravada::CONFIG->{"log"} if (! $LOG_FILENAME && exists $Ravada::CONFIG->{"log"});
     if ($LOG_FILENAME)
     {
         File::Path::make_path(File::Basename::dirname($LOG_FILENAME));

--- a/script/rvd_front
+++ b/script/rvd_front
@@ -1054,6 +1054,7 @@ get '/machine/check_access/(#id_domain)/(#user)' => sub {
     return _access_denied($c) if !$USER->is_admin;
 
     my $user_name = $c->stash('user');
+    return if !$user_name || $user_name eq 'undefined';
     my $user = Ravada::Auth::SQL->new(name => $user_name);
 
     if (!$user->id && Ravada::Auth::LDAP::search_user($user_name)) {

--- a/t/02_config.t
+++ b/t/02_config.t
@@ -42,6 +42,10 @@ sub check_db {
             }),1);
 }
 
+sub check_no_ldap {
+    is(rvd_front->feature('ldap'),0);
+}
+
 #########################################################################
 
 clean();
@@ -49,6 +53,8 @@ clean();
 check_empty();
 check_fail();
 check_db();
+
+check_no_ldap();
 
 end();
 

--- a/t/vm/20_base.t
+++ b/t/vm/20_base.t
@@ -95,6 +95,7 @@ sub test_display {
     # only test this for Void, it will fail on real VMs
     return if $vm_name ne 'Void';
 
+    unlock_hash(%$Ravada::CONFIG);
     $Ravada::CONFIG->{display_ip} = $DISPLAY_IP;
     eval { $display = $domain->display( user_admin ) };
     is($@,'');


### PR DESCRIPTION
This removes warnings on the JS console when it tried to load LDAP data.