### PR TITLE
fix: do not insert network twice

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -237,10 +237,11 @@ sub _add_internal_network($self) {
         ." VALUES(?,?,?,1,0)"
     );
     my $n=0;
+    my %done;
     for my $net (split /\n/,$out) {
         next if $net =~ /dev virbr/;
         my ($address) = $net =~ m{(^[\d\.]+/\d+)};
-        next if !$address;
+        next if !$address || $done{address}++;
         $sth->execute("internal$n",$address, ++$n+1);
 
     }


### PR DESCRIPTION
When there are more  than one interfaces connected to the same network, installation tries to add it and fails.
