### PR TITLE
fix: show clones checkbox was not working

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -499,7 +499,7 @@ ravadaApp.directive("solShowMachine", swMach)
     $scope.set_autostart= function(machineId, value) {
       $http.get("/machine/autostart/"+machineId+"/"+value);
     };
-    $scope.set_public = function(machineId, value) {
+    $scope.set_public = function(machineId, value, show_clones) {
       if (value) value=1;
       else value = 0;
       $http.get("/machine/public/"+machineId+"/"+value)
@@ -509,6 +509,9 @@ ravadaApp.directive("solShowMachine", swMach)
             }
         });
 
+       if ( value == 0 ) {
+        $http.get("/machine/set/"+machineId+"/show_clones/"+show_clones);
+       }
     };
 
     $scope.can_remove_base = function(machine) {

--- a/templates/main/admin_machines.html.ep
+++ b/templates/main/admin_machines.html.ep
@@ -240,7 +240,7 @@
                                </div>
                                <div class="modal-footer">
                                  <button type="button" class="btn btn-secondary" data-dismiss="modal" ng-click="cancel_modal(machine,'is_public')"><%=l 'No' %></button>
-                                 <button type="button" class="btn btn-primary" ng-click="cancel_modal();set_public(machine.id, machine.is_public)" data-dismiss="modal"><%=l 'Yes' %></button>
+                                 <button type="button" class="btn btn-primary" ng-click="cancel_modal();set_public(machine.id, machine.is_public, machine.show_clones)" data-dismiss="modal"><%=l 'Yes' %></button>
                                </div>
                              </div>
                            </div>


### PR DESCRIPTION
In admin machines, when removing from public, the show clones checkbox works now