### PR TITLE
Update en.po last string

### DIFF
--- a/lib/Ravada/I18N/en.po
+++ b/lib/Ravada/I18N/en.po
@@ -2170,5 +2170,5 @@ msgstr "Source Machine"
 msgid "Monitoring"
 msgstr "Monitoring"
 
-msgid "For Spice client setup follow this "
-msgstr "For Spice client setup follow this "
+msgid "Follow these steps for Spice client setup"
+msgstr "Follow these steps for Spice client setup"


### PR DESCRIPTION
Fix the string, it gets updated on the master but not on the develop branch. en.po of develop branch is the base language in Weblate, for this reason this string is not translated. This commit solve this issue.

#2048
