### PR TITLE
fix: new machines can not be created with negative swap values

### DIFF
--- a/lib/Ravada/Front.pm
+++ b/lib/Ravada/Front.pm
@@ -778,6 +778,7 @@ sub list_iso_images {
         $row->{options} = decode_json($row->{options})
             if $row->{options};
         $row->{min_ram} = 0.2 if !$row->{min_ram};
+        $row->{min_swap_size} = 0 if !$row->{min_swap_size};
         push @iso,($row);
     }
     $sth->finish;

--- a/templates/ng-templates/new_machine_template.html.ep
+++ b/templates/ng-templates/new_machine_template.html.ep
@@ -168,7 +168,7 @@
                 </label>
                 </div>
                 <div class="col-lg-2">
-                    <input class="form-control" ng-model="swap.value" type="number" min ="id_iso.min_swap_size" name="swap"  id="swap" ng-disabled="!swap.enabled || !_advanced_options"/>
+                    <input class="form-control" ng-model="swap.value" type="number" min ="{{id_iso.min_swap_size}}" name="swap"  id="swap" ng-disabled="!swap.enabled || !_advanced_options"/>
                 </div>
                 <div class="col-lg-1">
                    <a ng-show="!swap.enabled"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

New machines can not be created with negative swap values

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes issue #1831
