### PR TITLE
fix: use id_vm when number is passed

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -5999,7 +5999,10 @@ sub _cmd_list_storage_pools($self, $request) {
 sub _cmd_list_isos($self, $request){
     my $vm_type = $request->args('vm_type');
 
-    my $vm = Ravada::VM->open( type => $vm_type );
+    my @args = ( vm_type => $vm_type );
+    @args = ( $vm_type) if $vm_type =~ /^\d+$/;
+
+    my $vm = Ravada::VM->open( @args );
     $vm->refresh_storage();
     my @isos = sort { "\L$a" cmp "\L$b" } $vm->search_volume_path_re(qr(.*\.iso$));
 


### PR DESCRIPTION
This is required to support list isos by node for older versions in frontend