### PR TITLE
fix: ubuntu 26/24 ISO file_re

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -694,7 +694,7 @@ sub _update_isos {
             ,xml => 'bionic-amd64.xml'
             ,xml_volume => 'bionic64-volume.xml'
             ,url => 'https://ftp.lysator.liu.se/ubuntu-dvd/xubuntu/releases/26.04.*/release/'
-            ,file_re => 'xubuntu.*desktop.*.iso'
+            ,file_re => 'xubuntu.26.04.*desktop.*.iso'
             ,options => { machine => 'pc-q35', bios => 'UEFI' }
 	    ,min_ram => 2
 	    ,min_disk_size => '20'
@@ -706,7 +706,7 @@ sub _update_isos {
             ,xml => 'bionic-amd64.xml'
             ,xml_volume => 'bionic64-volume.xml'
             ,url => 'https://ftp.lysator.liu.se/ubuntu-dvd/xubuntu/releases/24.04.*/release/'
-            ,file_re => 'xubuntu.*desktop.*.iso'
+            ,file_re => 'xubuntu.24.04.*desktop.*.iso'
             ,options => { machine => 'pc-q35', bios => 'UEFI' }
 	    ,min_ram => 2
 	    ,min_disk_size => '20'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --
Fixed Xubuntu 26.04 filed_re declaration

## Description
<!--- Describe your changes in detail -->
Changed declaration in Xubuntu 26 and 24 in order to not generate conflicts when downloading one and the other is already installed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
