### PR TITLE
test: check ISO images entries are unique

### DIFF
--- a/.github/workflows/github-action-test.yml
+++ b/.github/workflows/github-action-test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Test mock VM
         run: prove -lr t/vm/60_new_args.t t/30_request.t
       - name: Test create from ISO
-        run: prove -lr t/request/25_create_from_iso.t t/vm/d10_not_download.t
+        run: prove -lr t/request/25_create_from_iso.t t/vm/d10_not_download.t t/repository/10_iso.t
       - name: Test hardware
         run: prove -lr t/request/30_hardware.t
       - name: Test downgrade

--- a/t/repository/10_iso.t
+++ b/t/repository/10_iso.t
@@ -139,8 +139,29 @@ sub test_post_login() {
     }
 }
 
+sub test_unique_entries() {
+    my $sth = connector->dbh->prepare("SELECT * FROM iso_images");
+    $sth->execute();
+    my %uniq;
+    while ( my $row = $sth->fetchrow_hashref) {
+        if (defined $row->{url}) {
+            if ( defined $row->{file_re} ) {
+                $row->{url_file_re}=$row->{url}." : ".$row->{file_re};
+            } else {
+                $row->{url_file_re}=$row->{url};
+            }
+        }
+        for my $field ( qw(name description url_file_re file_re)) {
+            my $value = $row->{$field};
+            next if !defined $value;
+            ok(!$uniq{$field}->{$value}++,"Expecting unique $field '$value'");
+        }
+    }
+}
+
 ####################################################################
 
+test_unique_entries();
 test_insert_locale();
 test_insert_request();
 

--- a/t/repository/10_iso.t
+++ b/t/repository/10_iso.t
@@ -165,6 +165,7 @@ sub test_unique_entries() {
 test_unique_entries();
 test_insert_locale();
 test_insert_request();
+test_unique_entries();
 
 SKIP: {
     skip("SKIPPED: Test must run as root",8) if $<;

--- a/t/repository/10_iso.t
+++ b/t/repository/10_iso.t
@@ -154,6 +154,7 @@ sub test_unique_entries() {
         for my $field ( qw(name description url_file_re file_re)) {
             my $value = $row->{$field};
             next if !defined $value;
+            $uniq{$field}->{$value} //= 0;
             ok(!$uniq{$field}->{$value}++,"Expecting unique $field '$value'");
         }
     }


### PR DESCRIPTION
Verifies names, descriptions and file regexp are unique. URLs may be duplicated but not concatenated with the file_re.

This will spot mistakes specially when file_re that happened in the past.
