### PR TITLE
Upgrade from parrot 7.1 to 7.3

### DIFF
--- a/lib/Ravada.pm
+++ b/lib/Ravada.pm
@@ -912,13 +912,13 @@ sub _update_isos {
             ,options => { machine => 'pc-q35'}
         }
 	,parrot_xfce_amd64 => {
-            name => 'Parrot Home Edition XFCE 7.1'
-            ,description => 'Parrot Home Edition XFCE 7.1 64 Bits'
+            name => 'Parrot Home Edition XFCE 7.3'
+            ,description => 'Parrot Home Edition XFCE 7.3 64 Bits'
             ,arch => 'x86_64'
             ,xml => 'jessie-amd64.xml'
             ,xml_volume => 'jessie-volume.xml'
-            ,url => 'https://download.parrot.sh/parrot/iso/7.1/'
-            ,file_re => 'Parrot-home-7\.1.*_amd64\.iso'
+            ,url => 'https://download.parrot.sh/parrot/iso/7.3/'
+            ,file_re => 'Parrot-home-7\.3.*_amd64\.iso'
             ,sha256_url => '$url/signed-hashes.txt'
             ,min_disk_size => '15'
         }
@@ -1584,7 +1584,9 @@ sub _update_table($self, $table, $field, $data, $verbose=0) {
 sub _remove_old_isos {
     my $self = shift;
     for my $sql (
-        "DELETE FROM iso_images "
+        "Delete FROM iso_images "
+            ."WHERE url like 'https://download.parrot.sh/parrot/iso/7.1/'"
+        ,"DELETE FROM iso_images "
             ."  WHERE url like '%debian-9.0%iso'"
         ,"DELETE FROM iso_images"
             ."  WHERE name like 'Debian%' "

--- a/script/rvd_back
+++ b/script/rvd_back
@@ -365,6 +365,23 @@ sub add_user {
 
     my $ravada = Ravada->new( %CONFIG);
 
+    my $sth_check = $ravada->_dbh->prepare(
+        "SELECT name ".
+        "FROM users ".
+        "WHERE name = ?"
+    );
+    $sth_check->execute($login);
+    my $usern = $sth_check->fetchrow();
+    while ($usern){
+        $usern = undef;
+        print "There is already a user with that username \n";
+        print "Try using another username \n";
+        $login = <STDIN>;
+        chomp $login;
+        $sth_check->execute($login);
+        $usern = $sth_check->fetchrow();
+    }
+
     print "$login password: ";
     ReadMode('noecho');
     my $password = <STDIN>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --> Upgrade from parrot 7.1 to 7.3

## Description
<!--- Describe your changes in detail --> Ravada will now download Parrot 7.3 ISO instead of Parrot 7.1 ISO

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
